### PR TITLE
feat(logging): add slog structured logging, LoggingConfig, and proc macros

### DIFF
--- a/rcal/Cargo.toml
+++ b/rcal/Cargo.toml
@@ -12,12 +12,19 @@ rcal_macros = { path = "./rcal_macros" }
 serde = { version = "1.0.229", features = ["derive"] }
 slog = "2.8.2"
 slog-async = "2.8.0"
+slog-json = "2.6.1"
 slog-term = "2.9.2"
 toml = "1.1.4"
 uuid = { version = "1.24.0", features = ["v1", "v3", "v4", "slog", "serde", "rng"] }
 omq-tokio = "0.21.1"
 tokio = { version = "1.53.1", features = ["full"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
+
+[[example]]
+name = "basic"
+
+[[example]]
+name = "custom_tokio"
 
 [[test]]
 name = "zmq_radio_dish"

--- a/rcal/examples/basic.rs
+++ b/rcal/examples/basic.rs
@@ -15,8 +15,8 @@ use slog::{error, info, warn};
 async fn main() {
     info!(root_logger, "basic example starting");
 
-    // `__rcal_config` and `root_logger` are injected by the macro.
-    let config = Arc::new(__rcal_config);
+    // `rcal_config` and `root_logger` are injected by the macro.
+    let config = Arc::new(rcal_config);
 
     let bus = match asb::get_asb("basic-example", "default", config, root_logger.clone()).await {
         Ok(b) => b,

--- a/rcal/examples/basic.rs
+++ b/rcal/examples/basic.rs
@@ -1,0 +1,35 @@
+//! Basic rcal_main example.
+//!
+//! Demonstrates the default `#[rcal_macros::rcal_main]` macro: injects a
+//! tokio runtime, loads CAL config, and creates a `root_logger`.
+//!
+//! Run:
+//!   RCAL_CONFIG=CALConfig.toml cargo run --example basic
+
+use std::sync::Arc;
+
+use rcal::asb;
+use slog::{error, info, warn};
+
+#[rcal_macros::rcal_main]
+async fn main() {
+    info!(root_logger, "basic example starting");
+
+    // `__rcal_config` and `root_logger` are injected by the macro.
+    let config = Arc::new(__rcal_config);
+
+    let bus = match asb::get_asb("basic-example", "default", config, root_logger.clone()).await {
+        Ok(b) => b,
+        Err(e) => {
+            error!(root_logger, "fatal: failed to create ASB"; "error" => %e);
+            std::process::exit(1);
+        }
+    };
+
+    info!(root_logger, "ASB created successfully");
+
+    match bus.lock().unwrap().close() {
+        Ok(()) => info!(root_logger, "done"),
+        Err(e) => warn!(root_logger, "ASB close error"; "error" => %e),
+    }
+}

--- a/rcal/examples/custom_tokio.rs
+++ b/rcal/examples/custom_tokio.rs
@@ -1,0 +1,38 @@
+//! Custom tokio runtime example.
+//!
+//! Demonstrates `#[rcal_macros::rcal_main]` with `tokio_main = false` so the
+//! caller can supply a custom `#[tokio::main]` attribute (e.g. to control
+//! worker thread count).
+//!
+//! Run:
+//!   RCAL_CONFIG=CALConfig.toml cargo run --example custom_tokio
+
+use std::sync::Arc;
+
+use rcal::asb;
+use slog::{error, info, warn};
+
+#[rcal_macros::rcal_main(tokio_main = false, logger = "my_logger")]
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() {
+    info!(my_logger, "custom_tokio example starting";
+          "workers" => 4);
+
+    // `__rcal_config` and `my_logger` are injected by the macro.
+    let config = Arc::new(__rcal_config);
+
+    let bus = match asb::get_asb("custom-example", "default", config, my_logger.clone()).await {
+        Ok(b) => b,
+        Err(e) => {
+            error!(my_logger, "fatal: failed to create ASB"; "error" => %e);
+            std::process::exit(1);
+        }
+    };
+
+    info!(my_logger, "ASB created successfully");
+
+    match bus.lock().unwrap().close() {
+        Ok(()) => info!(my_logger, "done"),
+        Err(e) => warn!(my_logger, "ASB close error"; "error" => %e),
+    }
+}

--- a/rcal/examples/custom_tokio.rs
+++ b/rcal/examples/custom_tokio.rs
@@ -18,8 +18,8 @@ async fn main() {
     info!(my_logger, "custom_tokio example starting";
           "workers" => 4);
 
-    // `__rcal_config` and `my_logger` are injected by the macro.
-    let config = Arc::new(__rcal_config);
+    // `rcal_config` and `my_logger` are injected by the macro.
+    let config = Arc::new(rcal_config);
 
     let bus = match asb::get_asb("custom-example", "default", config, my_logger.clone()).await {
         Ok(b) => b,

--- a/rcal/rcal_macros/Cargo.toml
+++ b/rcal/rcal_macros/Cargo.toml
@@ -3,6 +3,14 @@ name = "rcal_macros"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+
 [[test]]
 name = "integration"
 harness = true
@@ -11,3 +19,5 @@ harness = true
 slog = "2.8.2"
 slog-term = "2.9.2"
 slog-async = "2.8.0"
+rcal = { path = ".." }
+tokio = { version = "1.53.1", features = ["full"] }

--- a/rcal/rcal_macros/src/lib.rs
+++ b/rcal/rcal_macros/src/lib.rs
@@ -141,13 +141,11 @@ pub fn rcal_main(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let init = quote! {
-        let __rcal_config_path = rcal::asb::get_asb_config_location(#config_expr)
-            .map_err(|e| { eprintln!("rcal config error: {}", e); std::process::exit(1) })
-            .unwrap();
-        let __rcal_config = rcal::calconfig::parse_config_from_file(&__rcal_config_path)
-            .map_err(|e| { eprintln!("rcal config parse error: {}", e); std::process::exit(1) })
-            .unwrap();
-        let #logger_ident = rcal::logging::build_logger(&__rcal_config.system.logging);
+        let rcal_config_path = rcal::asb::get_asb_config_location(#config_expr)
+            .unwrap_or_else(|e| { eprintln!("rcal config error: {}", e); std::process::exit(1) });
+        let rcal_config = rcal::calconfig::parse_config_from_file(&rcal_config_path)
+            .unwrap_or_else(|e| { eprintln!("rcal config parse error: {}", e); std::process::exit(1) });
+        let #logger_ident = rcal::logging::build_logger(&rcal_config.system.logging);
     };
 
     let original_stmts = func.block.stmts.clone();

--- a/rcal/rcal_macros/src/lib.rs
+++ b/rcal/rcal_macros/src/lib.rs
@@ -1,17 +1,173 @@
-#[macro_export]
-macro_rules! init_test_logger {
-    () => ({
-        use slog::{Drain, Logger, o};
-        use slog_term::{FullFormat, TermDecorator};
-        use slog_async::Async;
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{
+    Ident, ItemFn, LitBool, LitStr, Token,
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+};
 
-        // Decorator that targets stdout for Cargo's test capture framework
-        let decorator = TermDecorator::new().stdout().build();
+// ── init_test_logger ──────────────────────────────────────────────────────────
 
-        // Mutex makes the drain safe to share across concurrent test threads
-        let drain = FullFormat::new(decorator).build().fuse();
-        let drain = Async::new(drain).build().fuse();
+/// Attribute macro for test functions. Injects a `logger` variable at the top
+/// of the function body, built via `rcal::logging::build_test_logger()`.
+///
+/// ```ignore
+/// #[init_test_logger]
+/// fn my_test() {
+///     slog::info!(logger, "hello");
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn init_test_logger(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut func = parse_macro_input!(item as ItemFn);
 
-        Logger::root(drain, o!("test_context" => "unit_tests"))
-    })
+    let init = quote! {
+        let logger = {
+            use slog::{Drain, Logger, o};
+            use slog_term::{FullFormat, PlainDecorator, TermDecorator};
+            use slog_async::Async;
+            if ::std::env::var("NO_COLOR").is_err() {
+                let d = FullFormat::new(TermDecorator::new().stdout().build()).build().fuse();
+                let d = Async::new(d).build().fuse();
+                Logger::root(d, o!("test_context" => "unit_tests"))
+            } else {
+                let d = FullFormat::new(PlainDecorator::new(::std::io::stdout())).build().fuse();
+                let d = Async::new(d).build().fuse();
+                Logger::root(d, o!("test_context" => "unit_tests"))
+            }
+        };
+    };
+
+    let original_stmts = func.block.stmts.clone();
+    let new_block: syn::Block = syn::parse_quote! {
+        {
+            #init
+            #(#original_stmts)*
+        }
+    };
+    *func.block = new_block;
+
+    quote!(#func).into()
+}
+
+// ── rcal_main ─────────────────────────────────────────────────────────────────
+
+/// Parsed arguments for `#[rcal_main(...)]`.
+struct RcalMainArgs {
+    tokio_main: bool,
+    logger: String,
+    config: Option<String>,
+}
+
+impl Default for RcalMainArgs {
+    fn default() -> Self {
+        Self {
+            tokio_main: true,
+            logger: "root_logger".to_string(),
+            config: None,
+        }
+    }
+}
+
+impl Parse for RcalMainArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut args = RcalMainArgs::default();
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+            match ident.to_string().as_str() {
+                "tokio_main" => {
+                    let val: LitBool = input.parse()?;
+                    args.tokio_main = val.value;
+                }
+                "logger" => {
+                    let val: LitStr = input.parse()?;
+                    args.logger = val.value();
+                }
+                "config" => {
+                    let val: LitStr = input.parse()?;
+                    args.config = Some(val.value());
+                }
+                other => {
+                    return Err(syn::Error::new(
+                        ident.span(),
+                        format!("unknown rcal_main argument: `{other}`"),
+                    ));
+                }
+            }
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+        Ok(args)
+    }
+}
+
+/// Attribute macro for `async fn main()` (or another async entry point).
+///
+/// Optionally prepends `#[tokio::main]`, loads the CAL config, and injects a
+/// logger variable built from that config.
+///
+/// Parameters (all optional):
+/// - `tokio_main = true|false` — whether to prepend `#[tokio::main]` (default `true`)
+/// - `logger = "name"` — variable name for the logger (default `"root_logger"`)
+/// - `config = "path"` — config file path; default uses `get_asb_config_location(None)`
+///
+/// # Examples
+///
+/// ```ignore
+/// #[rcal_macros::rcal_main]
+/// async fn main() {
+///     slog::info!(root_logger, "started");
+/// }
+///
+/// #[rcal_macros::rcal_main(tokio_main = false, logger = "log")]
+/// #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+/// async fn main() {
+///     slog::info!(log, "started with custom tokio");
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn rcal_main(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as RcalMainArgs);
+    let mut func = parse_macro_input!(item as ItemFn);
+
+    let logger_ident = Ident::new(&args.logger, Span::call_site());
+
+    let config_expr = match &args.config {
+        Some(path) => quote! { Some(#path.to_string()) },
+        None => quote! { None },
+    };
+
+    let init = quote! {
+        let __rcal_config_path = rcal::asb::get_asb_config_location(#config_expr)
+            .map_err(|e| { eprintln!("rcal config error: {}", e); std::process::exit(1) })
+            .unwrap();
+        let __rcal_config = rcal::calconfig::parse_config_from_file(&__rcal_config_path)
+            .map_err(|e| { eprintln!("rcal config parse error: {}", e); std::process::exit(1) })
+            .unwrap();
+        let #logger_ident = rcal::logging::build_logger(&__rcal_config.system.logging);
+    };
+
+    let original_stmts = func.block.stmts.clone();
+    let new_block: syn::Block = syn::parse_quote! {
+        {
+            #init
+            #(#original_stmts)*
+        }
+    };
+    *func.block = new_block;
+
+    let tokio_attr: Option<proc_macro2::TokenStream> = if args.tokio_main {
+        Some(quote! { #[tokio::main] })
+    } else {
+        None
+    };
+
+    quote! {
+        #tokio_attr
+        #func
+    }
+    .into()
 }

--- a/rcal/rcal_macros/tests/integration.rs
+++ b/rcal/rcal_macros/tests/integration.rs
@@ -1,8 +1,8 @@
 use rcal_macros::init_test_logger;
 use slog::info;
 
+#[init_test_logger]
 #[test]
 fn test_empty() {
-    let test_logger = init_test_logger!();
-    info!(test_logger, "A test log message");
+    info!(logger, "A test log message");
 }

--- a/rcal/src/asb/mod.rs
+++ b/rcal/src/asb/mod.rs
@@ -706,12 +706,12 @@ mod tests {
 
     static NEXT_PORT: AtomicU16 = AtomicU16::new(55700);
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_asb_factory_same_key_returns_same_instance() {
         let p1 = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
         let p2 = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
         let config = zmq::test_config_on_ports(&[p1, p2]);
-        let logger = init_test_logger!();
 
         let a = get_asb("test_svc", "TestZmq", Arc::clone(&config), logger.clone())
             .await
@@ -737,9 +737,9 @@ mod tests {
         );
     }
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_asb_factory_unknown_transport_returns_err() {
-        let logger = init_test_logger!();
         let no_default_config = Arc::new(
             parse_config_from_file(&get_test_config_path("calconfig_no_default.toml")).unwrap(),
         );

--- a/rcal/src/asb/zmq.rs
+++ b/rcal/src/asb/zmq.rs
@@ -148,6 +148,7 @@ impl ZmqAsb {
             let _ = radio.close().await;
         });
 
+        let logger = logger.new(slog::o!("subsystem" => "zmq"));
         Ok(Self {
             service_id: service_id.into(),
             asb_id: asb_id.into(),
@@ -278,6 +279,7 @@ impl AbstractServiceBus for ZmqAsb {
     }
 
     fn close(&mut self) -> CalResult<()> {
+        trace!(self.logger, "ZmqAsb::close()");
         // Dropping write_tx closes the channel; the background task exits and closes the socket.
         self.write_tx = None;
         Ok(())
@@ -295,6 +297,7 @@ type PollState<M> = Arc<(Mutex<VecDeque<(Instant, Arc<M>)>>, Condvar)>;
 /// RADIO socket background task.
 pub struct ZmqWriter<M: CalMessage> {
     topic: String,
+    logger: Logger,
     format: SerializationFormat,
     direct_tx: Option<tokio::sync::mpsc::UnboundedSender<Message>>,
     writer_buf: Option<Arc<Mutex<VecDeque<Message>>>>,
@@ -310,6 +313,7 @@ impl<M: CalMessage + serde::Serialize> AbstractWriter<M> for ZmqWriter<M> {
     }
 
     fn write(&mut self, message: &M) -> CalResult<()> {
+        trace!(self.logger, "ZmqWriter::write()"; "topic" => &self.topic);
         let xml = serialize_message(message, &self.format)?;
         // RADIO/DISH: part[0] = group (topic for DISH filtering), part[1] = payload
         let msg = Message::multipart([self.topic.clone(), xml]);
@@ -335,6 +339,7 @@ impl<M: CalMessage + serde::Serialize> AbstractWriter<M> for ZmqWriter<M> {
     }
 
     fn close(self: Box<Self>) -> CalResult<()> {
+        trace!(self.logger, "ZmqWriter::close()"; "topic" => &self.topic);
         if let Some(buf) = &self.writer_buf {
             let remaining = buf.lock().unwrap().len();
             if remaining > 0 {
@@ -374,6 +379,7 @@ impl<M: CalMessage + serde::Serialize> AbstractWriter<M> for ZmqWriter<M> {
 /// UDP-polarity transports (DISH binds, RADIO connects) are not supported.
 pub struct ZmqReader<M: CalMessage> {
     topic: String,
+    logger: Logger,
     listeners: Arc<Mutex<Vec<Arc<dyn MessageListener<M>>>>>,
     /// Shared queue + condvar for poll-mode delivery with expiration support.
     poll_state: PollState<M>,
@@ -407,6 +413,7 @@ impl<M: CalMessage + serde::de::DeserializeOwned> AbstractReader<M> for ZmqReade
     }
 
     fn read(&mut self, timeout: Option<Duration>) -> CalResult<Option<Arc<M>>> {
+        trace!(self.logger, "ZmqReader::read()"; "topic" => &self.topic, "timeout_ms" => timeout.map(|d| d.as_millis()));
         if !self.listeners.lock().unwrap().is_empty() {
             return Err(CalError::new(
                 CalErrorKind::OperationNotPermitted,
@@ -450,6 +457,7 @@ impl<M: CalMessage + serde::de::DeserializeOwned> AbstractReader<M> for ZmqReade
     }
 
     fn read_no_wait(&mut self) -> CalResult<Option<Arc<M>>> {
+        trace!(self.logger, "ZmqReader::read_no_wait()"; "topic" => &self.topic);
         if !self.listeners.lock().unwrap().is_empty() {
             return Err(CalError::new(
                 CalErrorKind::OperationNotPermitted,
@@ -467,6 +475,7 @@ impl<M: CalMessage + serde::de::DeserializeOwned> AbstractReader<M> for ZmqReade
     }
 
     fn close(self: Box<Self>) -> CalResult<()> {
+        trace!(self.logger, "ZmqReader::close()"; "topic" => &self.topic);
         self.task.abort();
         Ok(())
     }
@@ -526,8 +535,10 @@ where
             (Some(tx), None, None, None)
         };
 
+        trace!(self.logger, "ZmqAsb::create_writer()"; "topic" => topic);
         Ok(Box::new(ZmqWriter {
             topic: topic.to_string(),
+            logger: self.logger.new(slog::o!("topic" => topic.to_string())),
             format: self.serialization_format.clone(),
             direct_tx,
             writer_buf,
@@ -629,8 +640,10 @@ where
             poll_state_task.1.notify_all();
         });
 
+        trace!(self.logger, "ZmqAsb::create_reader()"; "topic" => topic);
         Ok(Box::new(ZmqReader {
             topic: topic.to_string(),
+            logger: self.logger.new(slog::o!("topic" => topic.to_string())),
             listeners,
             poll_state,
             task_alive,
@@ -731,9 +744,9 @@ mod tests {
 
     // ── Basic construction ────────────────────────────────────────────────
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_check_creation() {
-        let logger = init_test_logger!();
         let a = make_bus(logger).await;
         assert_eq!(a.oms_schema_version(), "2.1.0_test_schema");
         assert_eq!(a.oms_schema_compiler_version(), "0.1.0");
@@ -909,9 +922,9 @@ mod tests {
 
     // ── Status-listener tests ─────────────────────────────────────────────
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_status_listeners() {
-        let logger = init_test_logger!();
         let mut a = make_bus(logger).await;
 
         let l1 = Arc::new(TestStatusListener::new());
@@ -961,9 +974,9 @@ mod tests {
         drop(a);
     }
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_duplicate_register_returns_err() {
-        let logger = init_test_logger!();
         let mut a = make_bus(logger).await;
 
         let ld: Arc<dyn AsbStatusListener> = Arc::new(TestStatusListener::new());
@@ -975,9 +988,9 @@ mod tests {
         );
     }
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_unregister_unknown_returns_err() {
-        let logger = init_test_logger!();
         let mut a = make_bus(logger).await;
 
         let ld: Arc<dyn AsbStatusListener> = Arc::new(TestStatusListener::new());
@@ -988,9 +1001,9 @@ mod tests {
         );
     }
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_invalid_state_transition_returns_err() {
-        let logger = init_test_logger!();
         let mut a = make_bus(logger).await;
 
         a.update_status(AsbConnectionState::Normal, "").unwrap();
@@ -1011,9 +1024,9 @@ mod tests {
 
     // ── Writer tests ──────────────────────────────────────────────────────
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_writer_sends_message() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();
@@ -1058,9 +1071,9 @@ mod tests {
         asb.close().unwrap();
     }
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_writer_pretty_xml() {
-        let logger = init_test_logger!();
         let port = next_port();
         // Build config with pretty_xml format
         use crate::calconfig;
@@ -1117,9 +1130,9 @@ mod tests {
 
     // ── Reader tests ──────────────────────────────────────────────────────
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_reader_poll_mode() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();
@@ -1160,9 +1173,9 @@ mod tests {
         asb.close().unwrap();
     }
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_reader_read_no_wait_empty() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();
@@ -1183,9 +1196,9 @@ mod tests {
         asb.close().unwrap();
     }
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_reader_timeout_returns_none() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();
@@ -1207,9 +1220,9 @@ mod tests {
         asb.close().unwrap();
     }
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_reader_poll_fails_with_listener() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();
@@ -1244,9 +1257,9 @@ mod tests {
         asb.close().unwrap();
     }
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_reader_callback_mode() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();
@@ -1310,9 +1323,9 @@ mod tests {
 
     // ── QoS: TimeBasedFilter ──────────────────────────────────────────────
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_qos_time_based_filter() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();
@@ -1364,9 +1377,9 @@ mod tests {
 
     // ── QoS: Expiration ───────────────────────────────────────────────────
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_qos_expiration() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();
@@ -1407,9 +1420,9 @@ mod tests {
 
     // ── QoS: MessageBuffer (reader) ───────────────────────────────────────
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_qos_reader_buffer() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();
@@ -1452,9 +1465,9 @@ mod tests {
 
     // ── QoS: MessageBuffer (writer) ───────────────────────────────────────
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_qos_writer_buffer() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();
@@ -1509,9 +1522,9 @@ mod tests {
         asb.close().unwrap();
     }
 
+    #[init_test_logger]
     #[tokio::test]
     async fn test_writer_close_errors_on_unflushed() {
-        let logger = init_test_logger!();
         let port = next_port();
         let config = test_config_on_ports(&[port]);
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();

--- a/rcal/src/calconfig/mod.rs
+++ b/rcal/src/calconfig/mod.rs
@@ -119,20 +119,11 @@ impl Default for SinkConfig {
 }
 
 /// Logging configuration stored under `[system.logging]`.
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(default)]
 pub struct LoggingConfig {
     pub default_level: LogLevel,
     pub sink: Vec<SinkConfig>,
-}
-
-impl Default for LoggingConfig {
-    fn default() -> Self {
-        Self {
-            default_level: LogLevel::Warn,
-            sink: Vec::new(),
-        }
-    }
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]

--- a/rcal/src/calconfig/mod.rs
+++ b/rcal/src/calconfig/mod.rs
@@ -46,6 +46,95 @@ impl fmt::Display for CalConfig {
     }
 }
 
+/// Log level for a sink or global default.
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    #[default]
+    Warn,
+    Error,
+}
+
+impl From<LogLevel> for slog::Level {
+    fn from(l: LogLevel) -> Self {
+        match l {
+            LogLevel::Trace => slog::Level::Trace,
+            LogLevel::Debug => slog::Level::Debug,
+            LogLevel::Info => slog::Level::Info,
+            LogLevel::Warn => slog::Level::Warning,
+            LogLevel::Error => slog::Level::Error,
+        }
+    }
+}
+
+/// Log output format.
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum LogFormat {
+    /// Colored terminal output.
+    #[default]
+    Pretty,
+    /// Plaintext, no ANSI colors.
+    Basic,
+    /// key=value pairs (logfmt).
+    Logfmt,
+    /// JSON objects.
+    Json,
+}
+
+/// Log sink destination.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase", tag = "type")]
+pub enum SinkType {
+    #[default]
+    Stdout,
+    Stderr,
+    File { path: String },
+}
+
+/// Configuration for one log sink.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(default)]
+pub struct SinkConfig {
+    #[serde(flatten)]
+    pub sink_type: SinkType,
+    pub level: LogLevel,
+    pub format: LogFormat,
+    /// Subsystem names to include; empty = accept all.
+    pub subsystems: Vec<String>,
+}
+
+impl Default for SinkConfig {
+    fn default() -> Self {
+        Self {
+            sink_type: SinkType::Stdout,
+            level: LogLevel::Warn,
+            format: LogFormat::Pretty,
+            subsystems: Vec::new(),
+        }
+    }
+}
+
+/// Logging configuration stored under `[system.logging]`.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(default)]
+pub struct LoggingConfig {
+    pub default_level: LogLevel,
+    pub sink: Vec<SinkConfig>,
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            default_level: LogLevel::Warn,
+            sink: Vec::new(),
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 #[serde(default)]
 pub struct System {
@@ -53,6 +142,7 @@ pub struct System {
     pub label: Option<String>,
     pub uuid: UUID,
     pub default_transport: Option<String>,
+    pub logging: LoggingConfig,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]

--- a/rcal/src/lib.rs
+++ b/rcal/src/lib.rs
@@ -6,5 +6,6 @@
 
 pub mod asb;
 pub mod calconfig;
+pub mod logging;
 pub mod uci;
 pub mod xs;

--- a/rcal/src/logging.rs
+++ b/rcal/src/logging.rs
@@ -147,80 +147,54 @@ fn build_sink(sink: &SinkConfig) -> Option<BoxDrain> {
 
     macro_rules! make_async_drain {
         ($drain:expr) => {{
-            let fused = $drain.fuse();
-            let async_drain = Async::new(fused).build().fuse();
+            let async_drain = Async::new($drain.fuse()).build().fuse();
             let filtered = slog::LevelFilter::new(async_drain, level).fuse();
-            let boxed: BoxDrain = Box::new(filtered);
-            with_filter(boxed, sink.subsystems.clone())
+            with_filter(Box::new(filtered), sink.subsystems.clone())
         }};
     }
 
-    macro_rules! make_drain_for_writer {
-        ($writer:expr) => {
-            match sink.format {
+    match &sink.sink_type {
+        SinkType::Stdout | SinkType::Stderr => {
+            let stderr = matches!(sink.sink_type, SinkType::Stderr);
+            Some(match sink.format {
                 LogFormat::Pretty => {
-                    // Files get plaintext even when "pretty" is requested
-                    let d = FullFormat::new(PlainDecorator::new($writer)).build();
-                    Some(make_async_drain!(d))
+                    let dec = if stderr {
+                        TermDecorator::new().stderr().build()
+                    } else {
+                        TermDecorator::new().stdout().build()
+                    };
+                    make_async_drain!(FullFormat::new(dec).build())
                 }
                 LogFormat::Basic => {
-                    let d = FullFormat::new(PlainDecorator::new($writer)).build();
-                    Some(make_async_drain!(d))
+                    let w: Box<dyn std::io::Write + Send + Sync> =
+                        if stderr { Box::new(std::io::stderr()) } else { Box::new(std::io::stdout()) };
+                    make_async_drain!(FullFormat::new(PlainDecorator::new(w)).build())
                 }
                 LogFormat::Logfmt => {
-                    let d = LogfmtDrain { writer: std::sync::Mutex::new($writer) };
-                    Some(make_async_drain!(d))
+                    let w: Box<dyn std::io::Write + Send + Sync> =
+                        if stderr { Box::new(std::io::stderr()) } else { Box::new(std::io::stdout()) };
+                    make_async_drain!(LogfmtDrain { writer: std::sync::Mutex::new(w) })
                 }
                 LogFormat::Json => {
-                    let d = slog_json::Json::default($writer);
-                    Some(make_async_drain!(d))
+                    let w: Box<dyn std::io::Write + Send + Sync> =
+                        if stderr { Box::new(std::io::stderr()) } else { Box::new(std::io::stdout()) };
+                    make_async_drain!(slog_json::Json::default(w))
                 }
-            }
-        };
-    }
-
-    match &sink.sink_type {
-        SinkType::Stdout => match sink.format {
-            LogFormat::Pretty => {
-                let d = FullFormat::new(TermDecorator::new().stdout().build()).build();
-                Some(make_async_drain!(d))
-            }
-            LogFormat::Basic => {
-                let d = FullFormat::new(PlainDecorator::new(std::io::stdout())).build();
-                Some(make_async_drain!(d))
-            }
-            LogFormat::Logfmt => {
-                let d = LogfmtDrain { writer: std::sync::Mutex::new(std::io::stdout()) };
-                Some(make_async_drain!(d))
-            }
-            LogFormat::Json => {
-                let d = slog_json::Json::default(std::io::stdout());
-                Some(make_async_drain!(d))
-            }
-        },
-        SinkType::Stderr => match sink.format {
-            LogFormat::Pretty => {
-                let d = FullFormat::new(TermDecorator::new().stderr().build()).build();
-                Some(make_async_drain!(d))
-            }
-            LogFormat::Basic => {
-                let d = FullFormat::new(PlainDecorator::new(std::io::stderr())).build();
-                Some(make_async_drain!(d))
-            }
-            LogFormat::Logfmt => {
-                let d = LogfmtDrain { writer: std::sync::Mutex::new(std::io::stderr()) };
-                Some(make_async_drain!(d))
-            }
-            LogFormat::Json => {
-                let d = slog_json::Json::default(std::io::stderr());
-                Some(make_async_drain!(d))
-            }
-        },
+            })
+        }
         SinkType::File { path } => {
             let file = OpenOptions::new().create(true).append(true).open(path)
                 .map_err(|e| eprintln!("rcal logging: failed to open log file '{}': {}", path, e))
                 .ok()?;
-            make_drain_for_writer!(file)
+            Some(match sink.format {
+                LogFormat::Pretty | LogFormat::Basic => {
+                    make_async_drain!(FullFormat::new(PlainDecorator::new(file)).build())
+                }
+                LogFormat::Logfmt => {
+                    make_async_drain!(LogfmtDrain { writer: std::sync::Mutex::new(file) })
+                }
+                LogFormat::Json => make_async_drain!(slog_json::Json::default(file)),
+            })
         }
     }
 }

--- a/rcal/src/logging.rs
+++ b/rcal/src/logging.rs
@@ -1,0 +1,260 @@
+//! Logger construction from [`LoggingConfig`].
+
+use crate::calconfig::{LogFormat, LoggingConfig, SinkConfig, SinkType};
+use slog::{Drain, KV, Logger, o};
+use slog_async::Async;
+use slog_term::{FullFormat, PlainDecorator, TermDecorator};
+use std::fs::OpenOptions;
+use std::sync::Arc;
+
+// ── shared drain alias ────────────────────────────────────────────────────────
+
+type BoxDrain = Box<dyn Drain<Ok = (), Err = slog::Never> + Send + Sync>;
+
+// ── Subsystem-filtered drain ──────────────────────────────────────────────────
+
+struct SubsystemFilteredDrain {
+    inner: BoxDrain,
+    allowed: Vec<String>,
+}
+
+impl Drain for SubsystemFilteredDrain {
+    type Ok = ();
+    type Err = slog::Never;
+
+    fn log(
+        &self,
+        record: &slog::Record,
+        values: &slog::OwnedKVList,
+    ) -> Result<Self::Ok, Self::Err> {
+        let mut found = String::new();
+        {
+            let mut ser = SubsystemExtractor(&mut found);
+            let _ = values.serialize(record, &mut ser);
+            let _ = record.kv().serialize(record, &mut ser);
+        }
+        if self.allowed.iter().any(|a| a == &found) {
+            self.inner.log(record, values)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Extracts the value of the `"subsystem"` KV key.
+struct SubsystemExtractor<'a>(&'a mut String);
+
+impl<'a> slog::Serializer for SubsystemExtractor<'a> {
+    fn emit_str(&mut self, key: slog::Key, val: &str) -> slog::Result {
+        if key == "subsystem" {
+            self.0.clear();
+            self.0.push_str(val);
+        }
+        Ok(())
+    }
+
+    fn emit_arguments(&mut self, key: slog::Key, val: &std::fmt::Arguments) -> slog::Result {
+        if key == "subsystem" {
+            self.0.clear();
+            self.0.push_str(&val.to_string());
+        }
+        Ok(())
+    }
+}
+
+// ── Logfmt drain ─────────────────────────────────────────────────────────────
+
+struct LogfmtDrain<W: std::io::Write + Send + Sync + 'static> {
+    writer: std::sync::Mutex<W>,
+}
+
+impl<W: std::io::Write + Send + Sync + 'static> Drain for LogfmtDrain<W> {
+    type Ok = ();
+    type Err = slog::Never;
+
+    fn log(
+        &self,
+        record: &slog::Record,
+        values: &slog::OwnedKVList,
+    ) -> Result<Self::Ok, Self::Err> {
+        let mut buf = format!(
+            "level={} msg={:?}",
+            record.level().as_short_str().to_lowercase(),
+            record.msg().to_string(),
+        );
+        let mut ser = LogfmtSerializer(&mut buf);
+        let _ = values.serialize(record, &mut ser);
+        let _ = record.kv().serialize(record, &mut ser);
+        buf.push('\n');
+        let mut w = self.writer.lock().unwrap();
+        let _ = w.write_all(buf.as_bytes());
+        Ok(())
+    }
+}
+
+struct LogfmtSerializer<'a>(&'a mut String);
+
+impl<'a> slog::Serializer for LogfmtSerializer<'a> {
+    fn emit_arguments(&mut self, key: slog::Key, val: &std::fmt::Arguments) -> slog::Result {
+        let v = val.to_string();
+        if v.contains(' ') || v.contains('"') {
+            self.0.push_str(&format!(" {}={:?}", key, v));
+        } else {
+            self.0.push_str(&format!(" {}={}", key, v));
+        }
+        Ok(())
+    }
+}
+
+// ── Fanout drain ──────────────────────────────────────────────────────────────
+
+struct FanoutDrain {
+    drains: Arc<Vec<BoxDrain>>,
+}
+
+impl Drain for FanoutDrain {
+    type Ok = ();
+    type Err = slog::Never;
+
+    fn log(
+        &self,
+        record: &slog::Record,
+        values: &slog::OwnedKVList,
+    ) -> Result<Self::Ok, Self::Err> {
+        for d in self.drains.iter() {
+            let _ = d.log(record, values);
+        }
+        Ok(())
+    }
+}
+
+// Our drains are async and internally safe across unwind boundaries.
+unsafe impl Sync for FanoutDrain {}
+impl std::panic::UnwindSafe for FanoutDrain {}
+impl std::panic::RefUnwindSafe for FanoutDrain {}
+
+// ── Sink builder ─────────────────────────────────────────────────────────────
+
+fn with_filter(drain: BoxDrain, allowed: Vec<String>) -> BoxDrain {
+    if allowed.is_empty() {
+        drain
+    } else {
+        Box::new(SubsystemFilteredDrain { inner: drain, allowed })
+    }
+}
+
+fn build_sink(sink: &SinkConfig) -> Option<BoxDrain> {
+    let level: slog::Level = sink.level.into();
+
+    macro_rules! make_async_drain {
+        ($drain:expr) => {{
+            let fused = $drain.fuse();
+            let async_drain = Async::new(fused).build().fuse();
+            let filtered = slog::LevelFilter::new(async_drain, level).fuse();
+            let boxed: BoxDrain = Box::new(filtered);
+            with_filter(boxed, sink.subsystems.clone())
+        }};
+    }
+
+    macro_rules! make_drain_for_writer {
+        ($writer:expr) => {
+            match sink.format {
+                LogFormat::Pretty => {
+                    // Files get plaintext even when "pretty" is requested
+                    let d = FullFormat::new(PlainDecorator::new($writer)).build();
+                    Some(make_async_drain!(d))
+                }
+                LogFormat::Basic => {
+                    let d = FullFormat::new(PlainDecorator::new($writer)).build();
+                    Some(make_async_drain!(d))
+                }
+                LogFormat::Logfmt => {
+                    let d = LogfmtDrain { writer: std::sync::Mutex::new($writer) };
+                    Some(make_async_drain!(d))
+                }
+                LogFormat::Json => {
+                    let d = slog_json::Json::default($writer);
+                    Some(make_async_drain!(d))
+                }
+            }
+        };
+    }
+
+    match &sink.sink_type {
+        SinkType::Stdout => match sink.format {
+            LogFormat::Pretty => {
+                let d = FullFormat::new(TermDecorator::new().stdout().build()).build();
+                Some(make_async_drain!(d))
+            }
+            LogFormat::Basic => {
+                let d = FullFormat::new(PlainDecorator::new(std::io::stdout())).build();
+                Some(make_async_drain!(d))
+            }
+            LogFormat::Logfmt => {
+                let d = LogfmtDrain { writer: std::sync::Mutex::new(std::io::stdout()) };
+                Some(make_async_drain!(d))
+            }
+            LogFormat::Json => {
+                let d = slog_json::Json::default(std::io::stdout());
+                Some(make_async_drain!(d))
+            }
+        },
+        SinkType::Stderr => match sink.format {
+            LogFormat::Pretty => {
+                let d = FullFormat::new(TermDecorator::new().stderr().build()).build();
+                Some(make_async_drain!(d))
+            }
+            LogFormat::Basic => {
+                let d = FullFormat::new(PlainDecorator::new(std::io::stderr())).build();
+                Some(make_async_drain!(d))
+            }
+            LogFormat::Logfmt => {
+                let d = LogfmtDrain { writer: std::sync::Mutex::new(std::io::stderr()) };
+                Some(make_async_drain!(d))
+            }
+            LogFormat::Json => {
+                let d = slog_json::Json::default(std::io::stderr());
+                Some(make_async_drain!(d))
+            }
+        },
+        SinkType::File { path } => {
+            let file = OpenOptions::new().create(true).append(true).open(path).ok()?;
+            make_drain_for_writer!(file)
+        }
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Build a [`Logger`] from the provided [`LoggingConfig`].
+///
+/// If no sinks are configured the logger discards all output.
+pub fn build_logger(config: &LoggingConfig) -> Logger {
+    let drains: Vec<BoxDrain> = config.sink.iter().filter_map(build_sink).collect();
+
+    if drains.is_empty() {
+        return Logger::root(slog::Discard, o!());
+    }
+
+    let fanned = FanoutDrain { drains: Arc::new(drains) };
+    Logger::root(fanned.fuse(), o!())
+}
+
+/// Build a test logger: stdout, debug level.
+///
+/// Respects `NO_COLOR` — uses basic format when set.
+pub fn build_test_logger() -> Logger {
+    let use_color = std::env::var("NO_COLOR").is_err();
+    let async_drain = if use_color {
+        let d = FullFormat::new(TermDecorator::new().stdout().build())
+            .build()
+            .fuse();
+        Async::new(d).build().fuse()
+    } else {
+        let d = FullFormat::new(PlainDecorator::new(std::io::stdout()))
+            .build()
+            .fuse();
+        Async::new(d).build().fuse()
+    };
+    Logger::root(async_drain, o!("test_context" => "unit_tests"))
+}

--- a/rcal/src/logging.rs
+++ b/rcal/src/logging.rs
@@ -5,7 +5,6 @@ use slog::{Drain, KV, Logger, o};
 use slog_async::Async;
 use slog_term::{FullFormat, PlainDecorator, TermDecorator};
 use std::fs::OpenOptions;
-use std::sync::Arc;
 
 // ── shared drain alias ────────────────────────────────────────────────────────
 
@@ -87,7 +86,7 @@ impl<W: std::io::Write + Send + Sync + 'static> Drain for LogfmtDrain<W> {
         let _ = record.kv().serialize(record, &mut ser);
         buf.push('\n');
         let mut w = self.writer.lock().unwrap();
-        let _ = w.write_all(buf.as_bytes());
+        w.write_all(buf.as_bytes()).ok();
         Ok(())
     }
 }
@@ -109,7 +108,7 @@ impl<'a> slog::Serializer for LogfmtSerializer<'a> {
 // ── Fanout drain ──────────────────────────────────────────────────────────────
 
 struct FanoutDrain {
-    drains: Arc<Vec<BoxDrain>>,
+    drains: Vec<BoxDrain>,
 }
 
 impl Drain for FanoutDrain {
@@ -218,7 +217,9 @@ fn build_sink(sink: &SinkConfig) -> Option<BoxDrain> {
             }
         },
         SinkType::File { path } => {
-            let file = OpenOptions::new().create(true).append(true).open(path).ok()?;
+            let file = OpenOptions::new().create(true).append(true).open(path)
+                .map_err(|e| eprintln!("rcal logging: failed to open log file '{}': {}", path, e))
+                .ok()?;
             make_drain_for_writer!(file)
         }
     }
@@ -236,8 +237,10 @@ pub fn build_logger(config: &LoggingConfig) -> Logger {
         return Logger::root(slog::Discard, o!());
     }
 
-    let fanned = FanoutDrain { drains: Arc::new(drains) };
-    Logger::root(fanned.fuse(), o!())
+    let default_level: slog::Level = config.default_level.into();
+    let fanned = FanoutDrain { drains };
+    let filtered = slog::LevelFilter::new(fanned, default_level).fuse();
+    Logger::root(filtered, o!())
 }
 
 /// Build a test logger: stdout, debug level.

--- a/rcal/src/uci/base.rs
+++ b/rcal/src/uci/base.rs
@@ -432,10 +432,9 @@ mod tests {
     use rcal_macros::init_test_logger;
     use slog::debug;
 
+    #[init_test_logger]
     #[test]
     fn test_uuid_factory() {
-        let logger = init_test_logger!();
-
         debug!(logger, "Default (random): {}", UUID::generate());
         {
             let mut config = CAL_CONFIG.lock().unwrap();

--- a/rcal/tests/zmq_asb_system.rs
+++ b/rcal/tests/zmq_asb_system.rs
@@ -9,7 +9,6 @@ use std::time::Duration;
 use rcal::asb::zmq::ZmqAsb;
 use rcal::uci::CalMessage;
 use rcal::uci::base::{AbstractServiceBus, AbstractServiceBusExt, MessageListener, TopicQos};
-use rcal_macros::init_test_logger;
 
 // ── shared port allocator ─────────────────────────────────────────────────────
 
@@ -77,9 +76,9 @@ impl MessageListener<IntMsg> for CollectListener {
 ///   C — callback reader on "data" + polling reader on "status"
 ///
 /// Verifies fanout to two DISH sockets and simultaneous polling + callback modes.
+#[rcal_macros::init_test_logger]
 #[tokio::test]
 async fn test_three_clients_shared_bus() {
-    let logger = init_test_logger!();
     let mut bus = make_bus("Sys", next_port(), logger).await;
 
     let mut a_writer = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_writer(
@@ -166,9 +165,9 @@ async fn test_three_clients_shared_bus() {
 /// Cross-connections via `add_receive_peer`:
 ///   B.peer_uris = [port_a]
 ///   C.peer_uris = [port_a, port_b]
+#[rcal_macros::init_test_logger]
 #[tokio::test]
 async fn test_three_clients_separate_radios() {
-    let logger = init_test_logger!();
     let port_a = next_port();
     let port_b = next_port();
     let port_c = next_port();

--- a/rcal/tests/zmq_qos.rs
+++ b/rcal/tests/zmq_qos.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 use rcal::asb::zmq::ZmqAsb;
 use rcal::uci::CalMessage;
 use rcal::uci::base::{AbstractServiceBus, AbstractServiceBusExt, TopicQos};
-use rcal_macros::init_test_logger;
 
 // ── shared port allocator ─────────────────────────────────────────────────────
 
@@ -59,9 +58,9 @@ impl CalMessage for QosMsg {
 
 /// Sends a burst, verifies only the first passes, then verifies the filter resets
 /// after `min_separation` has elapsed.
+#[rcal_macros::init_test_logger]
 #[tokio::test]
 async fn test_qos_time_based_filter() {
-    let logger = init_test_logger!();
     let mut bus = make_bus("TBF", next_port(), logger).await;
 
     let reader_qos = TopicQos {
@@ -122,9 +121,9 @@ async fn test_qos_time_based_filter() {
 
 /// Writes messages, sleeps past max_age, verifies they expired.
 /// Then writes fresh messages and verifies they survive.
+#[rcal_macros::init_test_logger]
 #[tokio::test]
 async fn test_qos_expiration() {
-    let logger = init_test_logger!();
     let mut bus = make_bus("Exp", next_port(), logger).await;
 
     let reader_qos = TopicQos {
@@ -177,9 +176,9 @@ async fn test_qos_expiration() {
 // ── MessageBuffer (reader) ────────────────────────────────────────────────────
 
 /// Floods 5 messages into a cap-3 reader buffer; verifies oldest 2 dropped.
+#[rcal_macros::init_test_logger]
 #[tokio::test]
 async fn test_qos_reader_buffer() {
-    let logger = init_test_logger!();
     let mut bus = make_bus("RBuf", next_port(), logger).await;
 
     let reader_qos = TopicQos {


### PR DESCRIPTION
## Summary

Implements issue #20 — structured logging and tracing via `slog`.

- **`LoggingConfig`** added to `[system]` TOML section: configurable default level, multiple sinks (stdout/stderr/file), per-sink level filter, subsystem filter, and format (pretty/basic/logfmt/json)
- **`rcal::logging`** module: `build_logger()` constructs a fanout logger from config; custom `FanoutDrain`, `SubsystemFilteredDrain`, and `LogfmtDrain` (no extra dependency)
- **Trace logging** at every `Abstract*` API entry point in `ZmqAsb`, `ZmqWriter`, and `ZmqReader` using `slog::o!("subsystem" => "zmq")` child logger KV
- **`rcal_macros`** converted from `macro_rules!` to a proc-macro crate:
  - `#[init_test_logger]` attribute macro — injects `let logger = ...` at the top of a test function
  - `#[rcal_main]` attribute macro — loads config, builds logger, optionally prepends `#[tokio::main]`
- All unit and integration tests updated to use `#[init_test_logger]`
- Two examples added: `examples/basic.rs` (default `rcal_main`) and `examples/custom_tokio.rs` (`tokio_main = false` with custom flavor)

## Test plan

- [x] `cargo test` — all 39 tests pass (31 unit + 5 integration + 3 doc)
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo check --examples` — both examples compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)