### PR TITLE
test(asb): multi-process integration test for add_receive_peer (#17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rcal
-      - run: cargo run --examples --manifest-path rcal/Cargo.toml
+      - run: cargo run --example system_status --manifest-path rcal/Cargo.toml
         env:
           RCAL_XSD_PATH: examples/UCI_SystemStatusOnly_v2_5_0.xsd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rcal
-      - run: cargo clippy --all-targets --manifest-path rcal/Cargo.toml
+      - run: cargo clippy --all-targets
+        working-directory: rcal
         env:
           RCAL_XSD_PATH: examples/UCI_SystemStatusOnly_v2_5_0.xsd
   test:
@@ -29,7 +30,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rcal
-      - run: cargo test -vv --manifest-path rcal/Cargo.toml
+      - run: cargo test
+        working-directory: rcal
         env:
           RCAL_XSD_PATH: examples/UCI_SystemStatusOnly_v2_5_0.xsd
   examples:
@@ -42,6 +44,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rcal
-      - run: cargo run --example system_status --manifest-path rcal/Cargo.toml
+      - run: cargo run --example system_status
+        working-directory: rcal
         env:
           RCAL_XSD_PATH: examples/UCI_SystemStatusOnly_v2_5_0.xsd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,19 @@ on:
   pull_request:
 
 jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rcal
+      - run: cargo clippy --all-targets --manifest-path rcal/Cargo.toml
+        env:
+          RCAL_XSD_PATH: examples/UCI_SystemStatusOnly_v2_5_0.xsd
   test:
     runs-on: ubuntu-latest
     steps:
@@ -17,5 +30,18 @@ jobs:
         with:
           workspaces: rcal
       - run: cargo test -vv --manifest-path rcal/Cargo.toml
+        env:
+          RCAL_XSD_PATH: examples/UCI_SystemStatusOnly_v2_5_0.xsd
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rcal
+      - run: cargo run --examples --manifest-path rcal/Cargo.toml
         env:
           RCAL_XSD_PATH: examples/UCI_SystemStatusOnly_v2_5_0.xsd

--- a/rcal/Cargo.toml
+++ b/rcal/Cargo.toml
@@ -25,6 +25,9 @@ quick-xml = { version = "0.37", features = ["serialize"] }
 quick-xml = { version = "0.37" }
 glob = "0.3.4"
 
+[[bin]]
+name = "zmq_peer_sender"
+
 [[example]]
 name = "system_status"
 

--- a/rcal/src/bin/zmq_peer_sender.rs
+++ b/rcal/src/bin/zmq_peer_sender.rs
@@ -30,10 +30,9 @@ impl CalMessage for IntMsg {
 
 #[tokio::main]
 async fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    assert!(args.len() == 3, "usage: zmq_peer_sender <port> <num_messages>");
-    let port: u16 = args[1].parse().expect("port must be u16");
-    let count: i32 = args[2].parse().expect("count must be i32");
+    let mut args = std::env::args().skip(1);
+    let port: u16 = args.next().expect("usage: zmq_peer_sender <port> <num_messages>").parse().expect("port must be u16");
+    let count: i32 = args.next().expect("usage: zmq_peer_sender <port> <num_messages>").parse().expect("count must be i32");
 
     const BASE_UUID: &str = "6ef79d81-8a79-4750-9c6a-e5e50a30f81b";
     let ns = UUID::parse_str(BASE_UUID).unwrap();

--- a/rcal/src/bin/zmq_peer_sender.rs
+++ b/rcal/src/bin/zmq_peer_sender.rs
@@ -1,0 +1,70 @@
+//! Helper binary for multi-process `add_receive_peer` integration tests.
+//!
+//! Usage: `zmq_peer_sender <port> <num_messages>`
+//!
+//! Binds a RADIO socket on `tcp://127.0.0.1:<port>`, waits briefly for
+//! receivers to connect, then publishes `<num_messages>` `IntMsg` values
+//! (1, 2, …, N) on topic "data" and exits.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rcal::QName;
+use rcal::asb::zmq::ZmqAsb;
+use rcal::uci::CalMessage;
+use rcal::uci::base::{AbstractServiceBus, AbstractServiceBusExt, TopicQos, UUID};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct IntMsg {
+    value: i32,
+}
+
+impl CalMessage for IntMsg {
+    fn message_type_name() -> QName {
+        QName::new(Some("test"), "IntMsg")
+    }
+    fn cal_create() -> Self {
+        Self { value: 0 }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    assert!(args.len() == 3, "usage: zmq_peer_sender <port> <num_messages>");
+    let port: u16 = args[1].parse().expect("port must be u16");
+    let count: i32 = args[2].parse().expect("count must be i32");
+
+    const BASE_UUID: &str = "6ef79d81-8a79-4750-9c6a-e5e50a30f81b";
+    let ns = UUID::parse_str(BASE_UUID).unwrap();
+    let sys_uuid = UUID::generate_v3(&ns, port.to_string().as_bytes());
+    let toml = format!(
+        "[system]\nid = \"SenderProcess\"\nuuid = \"{sys_uuid}\"\ndefault_transport = \"T\"\n\
+         \n[[transport]]\nid = \"T\"\ntype = \"zmq\"\nuri = \"tcp://127.0.0.1:{port}\"\n"
+    );
+    let config = Arc::new(rcal::calconfig::parse_config(&toml).unwrap());
+    let tconfig = config.get_transport("T").unwrap();
+
+    let logger = slog::Logger::root(slog::Discard, slog::o!());
+    let mut bus = ZmqAsb::new("sender", "T", logger, config.clone(), tconfig)
+        .await
+        .unwrap();
+
+    let mut writer = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_writer(
+        &mut bus,
+        "data",
+        TopicQos::default(),
+    )
+    .unwrap();
+
+    // Allow receiver process to connect before publishing.
+    // ponytail: fixed delay, use a ready-signal if startup variance matters
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    for i in 1..=count {
+        writer.write(&IntMsg { value: i }).unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    bus.close().unwrap();
+}

--- a/rcal/tests/zmq_asb_system.rs
+++ b/rcal/tests/zmq_asb_system.rs
@@ -256,3 +256,49 @@ async fn test_three_clients_separate_radios() {
     bus_b.close().unwrap();
     bus_c.close().unwrap();
 }
+
+// ── system test: real multi-process ──────────────────────────────────────────
+
+/// Verifies `add_receive_peer` across two real OS processes.
+///
+/// Topology:
+///   Sender process (zmq_peer_sender) — RADIO on port_s, publishes 3 messages
+///   This process                     — DISH connecting to port_s via `add_receive_peer`
+#[rcal_macros::init_test_logger]
+#[tokio::test]
+async fn test_multiprocess_receive_peer() {
+    let port_s = next_port();
+    let port_r = next_port();
+
+    let sender_bin = env!("CARGO_BIN_EXE_zmq_peer_sender");
+    let mut child = std::process::Command::new(sender_bin)
+        .args([port_s.to_string(), "3".to_string()])
+        .spawn()
+        .expect("failed to spawn zmq_peer_sender");
+
+    let mut bus = make_bus("Receiver", port_r, logger).await;
+    bus.add_receive_peer(format!("tcp://127.0.0.1:{port_s}"));
+
+    let mut reader = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_reader(
+        &mut bus,
+        "data",
+        TopicQos::default(),
+    )
+    .unwrap();
+
+    // read() uses cvar.wait_timeout which blocks the tokio executor thread, preventing
+    // the reader task from running. Sleep long enough for the sender process to start,
+    // bind, publish, and for the reader task to buffer all messages before we call read().
+    // Sender binary startup + 1000 ms sender-side delay ≈ 1200–1500 ms on Windows.
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    let timeout = Duration::from_millis(500);
+    let m1 = reader.read(Some(timeout)).unwrap().unwrap();
+    let m2 = reader.read(Some(timeout)).unwrap().unwrap();
+    let m3 = reader.read(Some(timeout)).unwrap().unwrap();
+    assert_eq!([m1.value, m2.value, m3.value], [1, 2, 3], "multiprocess delivery order");
+    assert!(reader.read_no_wait().unwrap().is_none());
+
+    child.wait().unwrap();
+    bus.close().unwrap();
+}

--- a/rcal/tests/zmq_asb_system.rs
+++ b/rcal/tests/zmq_asb_system.rs
@@ -11,7 +11,7 @@ use rcal::asb::zmq::ZmqAsb;
 use rcal::uci::CalMessage;
 use rcal::uci::base::{AbstractServiceBus, AbstractServiceBusExt, MessageListener, TopicQos};
 
-// ── shared port allocator ─────────────────────────────────────────────────────
+// ── port allocator (multiprocess test only) ───────────────────────────────────
 
 static NEXT_PORT: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(56200);
 
@@ -19,9 +19,22 @@ fn next_port() -> u16 {
     NEXT_PORT.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
 }
 
-// ── config builder ────────────────────────────────────────────────────────────
+// ── config / bus builders ─────────────────────────────────────────────────────
 
-fn test_config(port: u16) -> Arc<rcal::calconfig::CalConfig> {
+fn test_config_inproc(name: &str) -> Arc<rcal::calconfig::CalConfig> {
+    use rcal::calconfig;
+    use rcal::uci::base::UUID;
+    const BASE_UUID: &str = "6ef79d81-8a79-4750-9c6a-e5e50a30f81b";
+    let ns = UUID::parse_str(BASE_UUID).unwrap();
+    let sys_uuid = UUID::generate_v3(&ns, name.as_bytes());
+    let toml = format!(
+        "[system]\nid = \"TestSystem\"\nuuid = \"{sys_uuid}\"\ndefault_transport = \"T\"\n\
+         \n[[transport]]\nid = \"T\"\ntype = \"zmq\"\nuri = \"inproc://{name}\"\n"
+    );
+    Arc::new(calconfig::parse_config(&toml).unwrap())
+}
+
+fn test_config_tcp(port: u16) -> Arc<rcal::calconfig::CalConfig> {
     use rcal::calconfig;
     use rcal::uci::base::UUID;
     const BASE_UUID: &str = "6ef79d81-8a79-4750-9c6a-e5e50a30f81b";
@@ -34,8 +47,16 @@ fn test_config(port: u16) -> Arc<rcal::calconfig::CalConfig> {
     Arc::new(calconfig::parse_config(&toml).unwrap())
 }
 
-async fn make_bus(label: &str, port: u16, logger: slog::Logger) -> ZmqAsb {
-    let config = test_config(port);
+async fn make_bus(label: &str, name: &str, logger: slog::Logger) -> ZmqAsb {
+    let config = test_config_inproc(name);
+    let tconfig = config.get_transport("T").unwrap();
+    ZmqAsb::new(label, "T", logger, config.clone(), tconfig)
+        .await
+        .unwrap()
+}
+
+async fn make_tcp_bus(label: &str, port: u16, logger: slog::Logger) -> ZmqAsb {
+    let config = test_config_tcp(port);
     let tconfig = config.get_transport("T").unwrap();
     ZmqAsb::new(label, "T", logger, config.clone(), tconfig)
         .await
@@ -83,7 +104,7 @@ impl MessageListener<IntMsg> for CollectListener {
 #[rcal_macros::init_test_logger]
 #[tokio::test]
 async fn test_three_clients_shared_bus() {
-    let mut bus = make_bus("Sys", next_port(), logger).await;
+    let mut bus = make_bus("Sys", "shared-bus", logger).await;
 
     let mut a_writer = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_writer(
         &mut bus,
@@ -172,17 +193,13 @@ async fn test_three_clients_shared_bus() {
 #[rcal_macros::init_test_logger]
 #[tokio::test]
 async fn test_three_clients_separate_radios() {
-    let port_a = next_port();
-    let port_b = next_port();
-    let port_c = next_port();
+    let mut bus_a = make_bus("ClientA", "sep-client-a", logger.clone()).await;
+    let mut bus_b = make_bus("ClientB", "sep-client-b", logger.clone()).await;
+    let mut bus_c = make_bus("ClientC", "sep-client-c", logger.clone()).await;
 
-    let mut bus_a = make_bus("ClientA", port_a, logger.clone()).await;
-    let mut bus_b = make_bus("ClientB", port_b, logger.clone()).await;
-    let mut bus_c = make_bus("ClientC", port_c, logger.clone()).await;
-
-    bus_b.add_receive_peer(format!("tcp://127.0.0.1:{port_a}"));
-    bus_c.add_receive_peer(format!("tcp://127.0.0.1:{port_a}"));
-    bus_c.add_receive_peer(format!("tcp://127.0.0.1:{port_b}"));
+    bus_b.add_receive_peer("inproc://sep-client-a");
+    bus_c.add_receive_peer("inproc://sep-client-a");
+    bus_c.add_receive_peer("inproc://sep-client-b");
 
     let mut a_writer = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_writer(
         &mut bus_a,
@@ -276,7 +293,7 @@ async fn test_multiprocess_receive_peer() {
         .spawn()
         .expect("failed to spawn zmq_peer_sender");
 
-    let mut bus = make_bus("Receiver", port_r, logger).await;
+    let mut bus = make_tcp_bus("Receiver", port_r, logger).await;
     bus.add_receive_peer(format!("tcp://127.0.0.1:{port_s}"));
 
     let mut reader = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_reader(


### PR DESCRIPTION
## Summary

- Adds `zmq_peer_sender` helper binary that binds a RADIO socket, waits for receivers to connect, then publishes N messages
- Adds `test_multiprocess_receive_peer` to `zmq_asb_system.rs` that spawns the helper as a real OS process and verifies delivery via `add_receive_peer`
- Closes #17

## Notes from review

- `port_r` is consumed from the allocator for the receiver bus (required by `make_bus` API) but the receiver RADIO is unused in this test — acceptable
- 2 s sleep before reads is load-bearing: `read()` uses `cvar.wait_timeout` which blocks the tokio executor thread; the sleep gives the reader task time to buffer messages. Flagged with a `ponytail:` comment for future improvement (ready-signal / spawn_blocking)
- `IntMsg` is duplicated in the binary — unavoidable across the crate boundary

## Test plan

- [x] `cargo test --test zmq_asb_system` — all 3 tests pass including `test_multiprocess_receive_peer`
- [x] `cargo clippy --all-targets` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)