### PR TITLE
feat(xs): replace DateTime i64 alias with chrono::DateTime<Utc> newtype

### DIFF
--- a/rcal/Cargo.toml
+++ b/rcal/Cargo.toml
@@ -20,6 +20,7 @@ uuid = { version = "1.24.0", features = ["v1", "v3", "v4", "slog", "serde", "rng
 omq-tokio = "0.21.1"
 tokio = { version = "1.53.1", features = ["full"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
+chrono = { version = "0.4.45", features = ["serde"] }
 
 [build-dependencies]
 quick-xml = { version = "0.37" }
@@ -48,3 +49,6 @@ harness = true
 [[test]]
 name = "zmq_qos"
 harness = true
+
+[dev-dependencies]
+serde_json = "1.0.151"

--- a/rcal/build.rs
+++ b/rcal/build.rs
@@ -719,7 +719,9 @@ fn generate_types(schema: &Schema, out_dir: &Path) {
         mod_entries.join("\n")
     );
     fs::write(out_dir.join("mod.rs"), mod_content).unwrap();
-    eprintln!("Finished generating types: {element_count} elements, {simple_count} simple types, and {complex_count} complex typtes");
+    eprintln!(
+        "Finished generating types: {element_count} elements, {simple_count} simple types, and {complex_count} complex typtes"
+    );
 }
 
 fn gen_enum(name: &str, vals: &[String]) -> String {

--- a/rcal/src/bin/zmq_peer_sender.rs
+++ b/rcal/src/bin/zmq_peer_sender.rs
@@ -31,8 +31,16 @@ impl CalMessage for IntMsg {
 #[tokio::main]
 async fn main() {
     let mut args = std::env::args().skip(1);
-    let port: u16 = args.next().expect("usage: zmq_peer_sender <port> <num_messages>").parse().expect("port must be u16");
-    let count: i32 = args.next().expect("usage: zmq_peer_sender <port> <num_messages>").parse().expect("count must be i32");
+    let port: u16 = args
+        .next()
+        .expect("usage: zmq_peer_sender <port> <num_messages>")
+        .parse()
+        .expect("port must be u16");
+    let count: i32 = args
+        .next()
+        .expect("usage: zmq_peer_sender <port> <num_messages>")
+        .parse()
+        .expect("count must be i32");
 
     const BASE_UUID: &str = "6ef79d81-8a79-4750-9c6a-e5e50a30f81b";
     let ns = UUID::parse_str(BASE_UUID).unwrap();

--- a/rcal/src/xs.rs
+++ b/rcal/src/xs.rs
@@ -20,7 +20,7 @@
 //! | `xs:float`         | `f32`                   | OMSC-SPC-008 Table 9.1-1   |
 //! | `xs:integer`       | `i64`                   | **CERT CAL-016024**        |
 //! | `xs:duration`      | `i64` (nanoseconds)     | **CERT CAL-016027**        |
-//! | `xs:dateTime`      | `i64` (ns since epoch)  | **CERT CAL-016028**        |
+//! | `xs:dateTime`      | `DateTime` (chrono UTC) | **CERT CAL-016028**        |
 //! | `xs:time`          | `i64` (ns since 00:00Z) | **CERT CAL-016029**        |
 //! | `xs:string`        | `String`                | OMSC-SPC-008 Table 9.1-2   |
 //! | `xs:hexBinary`     | `Vec<u8>`               | OMSC-SPC-008 Table 9.1-3   |
@@ -90,11 +90,64 @@ pub type Integer = i64;
 /// Positive values indicate forward durations; negative indicate backward.
 pub type Duration = i64;
 
-/// `xs:dateTime` — nanoseconds since the POSIX epoch (1970-01-01T00:00:00Z).
+/// `xs:dateTime` — UTC instant wrapping [`chrono::DateTime<chrono::Utc>`].
 ///
-/// **CERT CAL-016028**: represented as a signed 64-bit integer.
-/// Negative values represent dates before the POSIX epoch.
-pub type DateTime = i64;
+/// **CERT CAL-016028**: serialised as a signed 64-bit integer of nanoseconds
+/// since the POSIX epoch (1970-01-01T00:00:00Z).  Negative values represent
+/// instants before the epoch.  Use [`DateTime::from`] / [`Into<i64>`] to
+/// convert to/from the raw nanosecond representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DateTime(chrono::DateTime<chrono::Utc>);
+
+impl Default for DateTime {
+    fn default() -> Self {
+        Self(chrono::DateTime::UNIX_EPOCH)
+    }
+}
+
+impl DateTime {
+    /// Current UTC time.
+    pub fn now() -> Self {
+        Self(chrono::Utc::now())
+    }
+}
+
+impl From<chrono::DateTime<chrono::Utc>> for DateTime {
+    fn from(dt: chrono::DateTime<chrono::Utc>) -> Self {
+        Self(dt)
+    }
+}
+
+impl From<DateTime> for chrono::DateTime<chrono::Utc> {
+    fn from(dt: DateTime) -> Self {
+        dt.0
+    }
+}
+
+impl From<i64> for DateTime {
+    fn from(ns: i64) -> Self {
+        Self(chrono::DateTime::from_timestamp_nanos(ns))
+    }
+}
+
+impl From<DateTime> for i64 {
+    fn from(dt: DateTime) -> Self {
+        // Returns i64::MAX for chrono::DateTime values outside the i64-nanosecond range.
+        dt.0.timestamp_nanos_opt().unwrap_or(i64::MAX)
+    }
+}
+
+impl serde::Serialize for DateTime {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        chrono::serde::ts_nanoseconds::serialize(&self.0, s)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for DateTime {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        chrono::serde::ts_nanoseconds::deserialize(d).map(DateTime)
+    }
+}
 
 /// `xs:time` — nanoseconds since 00:00:00.000000000Z of the current day.
 ///
@@ -135,11 +188,36 @@ mod tests {
     }
 
     #[test]
-    fn time_types_are_i64() {
-        // CERT CAL-016027 / CAL-016028 / CAL-016029
+    fn duration_and_time_are_i64() {
+        // CERT CAL-016027 / CAL-016029
         let _: Duration = 1_000_000_000_i64; // 1 second in ns
-        let _: DateTime = 0_i64; // POSIX epoch
         let _: Time = 0_i64; // midnight
+    }
+
+    #[test]
+    fn datetime_roundtrips_nanoseconds() {
+        // CERT CAL-016028: nanosecond integer round-trip
+        let epoch = DateTime::from(0_i64);
+        assert_eq!(i64::from(epoch), 0_i64);
+
+        let ns: i64 = 1_700_000_000_000_000_000;
+        let dt = DateTime::from(ns);
+        assert_eq!(i64::from(dt), ns);
+    }
+
+    #[test]
+    fn datetime_serializes_as_i64() {
+        let dt = DateTime::from(42_i64);
+        let json = serde_json::to_string(&dt).expect("serialize");
+        assert_eq!(json, "42");
+        let back: DateTime = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(i64::from(back), 42_i64);
+    }
+
+    #[test]
+    fn datetime_now_is_positive() {
+        let ns = i64::from(DateTime::now());
+        assert!(ns > 0, "now() should be after epoch");
     }
 
     #[test]

--- a/rcal/tests/zmq_asb_system.rs
+++ b/rcal/tests/zmq_asb_system.rs
@@ -313,7 +313,11 @@ async fn test_multiprocess_receive_peer() {
     let m1 = reader.read(Some(timeout)).unwrap().unwrap();
     let m2 = reader.read(Some(timeout)).unwrap().unwrap();
     let m3 = reader.read(Some(timeout)).unwrap().unwrap();
-    assert_eq!([m1.value, m2.value, m3.value], [1, 2, 3], "multiprocess delivery order");
+    assert_eq!(
+        [m1.value, m2.value, m3.value],
+        [1, 2, 3],
+        "multiprocess delivery order"
+    );
     assert!(reader.read_no_wait().unwrap().is_none());
 
     child.wait().unwrap();


### PR DESCRIPTION
Closes #28

## Summary

- `xs::DateTime` is now a newtype struct wrapping `chrono::DateTime<Utc>` instead of a bare `i64`
- Wire format is unchanged: serialises as a signed i64 nanoseconds since POSIX epoch via `chrono::serde::ts_nanoseconds`
- Conversions provided: `From<i64>`, `Into<i64>`, `From<chrono::DateTime<Utc>>`, `Into<chrono::DateTime<Utc>>`
- `Default` is `UNIX_EPOCH` (`chrono::DateTime::UNIX_EPOCH`)
- `DateTime::now()` constructor added
- Added `chrono = { version = "0.4", features = ["serde"] }` as a dependency
- Added `serde_json` as a dev-dependency for the serialisation unit test

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p rcal --lib` — 49 tests pass including 3 new DateTime-specific tests
- [x] `cargo clippy -p rcal` — no warnings
- [x] `cargo fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)