### PR TITLE
feat(service): AbstractService trait and simple_two_service example

### DIFF
--- a/rcal/Cargo.toml
+++ b/rcal/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["rcal_macros", "xsd-subset"]
+members = ["rcal_macros", "xsd-subset", "examples/simple_two_service"]
 
 [workspace.package]
 version = "1.0.0"
@@ -14,6 +14,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "OMS Critical Abstraction Layer (CAL) implementation for Rust"
+
+[features]
+service = []
+default = ["service"]
 
 [dependencies]
 lazy_static = "1.5.0"

--- a/rcal/Cargo.toml
+++ b/rcal/Cargo.toml
@@ -17,7 +17,8 @@ description = "OMS Critical Abstraction Layer (CAL) implementation for Rust"
 
 [features]
 service = []
-default = ["service"]
+zmq = ["dep:omq-tokio"]
+default = ["service", "zmq"]
 
 [dependencies]
 lazy_static = "1.5.0"
@@ -35,10 +36,6 @@ omq-tokio = { version = "0.21.1", optional = true }
 tokio = { version = "1.53.1", features = ["full"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
 chrono = { version = "0.4.45", features = ["serde"] }
-
-[features]
-zmq = ["dep:omq-tokio"]
-default = ["zmq"]
 
 [build-dependencies]
 quick-xml = { version = "0.37" }

--- a/rcal/examples/simple_two_service/.cargo/config.toml
+++ b/rcal/examples/simple_two_service/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+linker = "C:\\Users\\clarketr\\msvc\\VC\\Tools\\MSVC\\14.51.36231\\bin\\Hostx64\\x64\\link.exe"
+
+[env]
+RCAL_CALCONFIG_PATH = { value = "src/ExampleConfig.toml", relative = true }

--- a/rcal/examples/simple_two_service/Cargo.toml
+++ b/rcal/examples/simple_two_service/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "simple_two_service"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "simple_two_service"
+
+[dependencies]
+rcal = { path = "../..", features = ["service"] }
+rcal_macros = { path = "../../rcal_macros" }
+tokio = { version = "1", features = ["full"] }
+slog = "2"
+chrono = "0.4"

--- a/rcal/examples/simple_two_service/src/ExampleConfig.toml
+++ b/rcal/examples/simple_two_service/src/ExampleConfig.toml
@@ -1,0 +1,59 @@
+[system]
+id = "TestSystem"
+label = "OMS Test System with 2 services"
+uuid = "6ef79d81-8a79-4750-9c6a-e5e50a30f81b"
+
+[system.logging]
+default_level = "info"
+
+[[system.logging.sink]]
+type = "stdout"
+level = "trace"
+format = "pretty"
+
+# Two transports on consecutive ports (base 2000) so each service
+# can bind its own RADIO socket and peer-connect to the other.
+[[transport]]
+id = "service1"
+type = "zmq"
+uri = "tcp://127.0.0.1:2000"
+
+[[transport]]
+id = "service2"
+type = "zmq"
+uri = "tcp://127.0.0.1:2001"
+
+[[service]]
+id = "TestService1"
+transport = "service1"
+status_delay = "1s"
+service_status_data_request_enable = true
+
+[[service.topic]]
+id = "SystemStatus"
+
+[[service.topic]]
+id = "ServiceStatus"
+
+[[service.topic]]
+id = "ServiceStatusDataRequest"
+
+[[service.topic]]
+id = "ServiceStatusDataRequestStatus"
+
+[[service]]
+id = "TestService2"
+transport = "service2"
+status_delay = "1s"
+
+[[service.topic]]
+id = "SystemStatus"
+
+[[service.topic]]
+id = "ServiceStatus"
+
+[[service.topic]]
+id = "ServiceStatusDataRequest"
+
+[[service.topic]]
+id = "ServiceStatusDataRequestStatus"

--- a/rcal/examples/simple_two_service/src/main.rs
+++ b/rcal/examples/simple_two_service/src/main.rs
@@ -1,0 +1,257 @@
+//! Two-service OMS example demonstrating AbstractService lifecycle,
+//! periodic status broadcasting, and ServiceStatusDataRequest/response.
+//!
+//! # Running
+//!
+//! Open two terminals and run each command in one:
+//!
+//! ```text
+//! cargo run -- TestService1 3
+//! cargo run -- TestService2 3
+//! ```
+//!
+//! TestService1 binds on port 2000; TestService2 on port 2001. Each peers
+//! to the other so all topics flow bidirectionally.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use slog::{error, info, o, warn};
+
+use rcal::asb::TopicQos;
+use rcal::asb::zmq::ZmqAsb;
+use rcal::service::{AbstractService, AbstractServiceImpl};
+use rcal::uci::types::*;
+use rcal::update_message_header;
+
+#[rcal_macros::rcal_main]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    let service_name = match args.get(1) {
+        Some(n) => n.clone(),
+        None => {
+            eprintln!("Usage: simple_two_service <TestService1|TestService2> [request_count]");
+            std::process::exit(1);
+        }
+    };
+
+    let request_count: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(3);
+
+    let config = Arc::new(rcal_config);
+
+    // Each service uses a distinct port so both can bind their own RADIO socket.
+    // The peer URI points to the other service's RADIO.
+    // Delays are staggered per service to make concurrent output easier to visualize.
+    let (transport_id, peer_uri, request_delay) = match service_name.as_str() {
+        "TestService1" => ("service1", "tcp://127.0.0.1:2001", Duration::from_secs(3)),
+        "TestService2" => ("service2", "tcp://127.0.0.1:2000", Duration::from_secs(5)),
+        other => {
+            error!(root_logger, "unknown service name; use TestService1 or TestService2";
+                "name" => other);
+            std::process::exit(1);
+        }
+    };
+
+    let tconfig = match config.get_transport(transport_id) {
+        Some(t) => t.clone(),
+        None => {
+            error!(root_logger, "transport not in config"; "id" => transport_id);
+            std::process::exit(1);
+        }
+    };
+
+    let mut asb = match ZmqAsb::new(
+        &service_name,
+        transport_id,
+        root_logger.clone(),
+        Arc::clone(&config),
+        &tconfig,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => {
+            error!(root_logger, "ZmqAsb init failed"; "error" => %e);
+            std::process::exit(1);
+        }
+    };
+
+    // Connect the DISH side to the other service's RADIO.
+    asb.add_receive_peer(peer_uri);
+
+    let mut svc = AbstractServiceImpl::new(
+        service_name.clone(),
+        config.system.id.clone(),
+        vec![],
+        asb,
+        Arc::clone(&config),
+        root_logger.clone(),
+    );
+
+    if let Err(e) = svc.activate() {
+        error!(root_logger, "activate failed"; "error" => %e);
+        std::process::exit(1);
+    }
+
+    info!(root_logger, "service started";
+        "service" => &service_name,
+        "transport" => transport_id,
+        "peer" => peer_uri,
+    );
+
+    // ── Periodic SystemStatus ──────────────────────────────────────────────────
+
+    let mut sys_writer =
+        match svc.create_writer::<SystemStatus_>("SystemStatus", TopicQos::default()) {
+            Ok(w) => w,
+            Err(e) => {
+                error!(root_logger, "create SystemStatus writer failed"; "error" => %e);
+                std::process::exit(1);
+            }
+        };
+    let mut sys_msg = svc
+        .create_message::<SystemStatus_>()
+        .expect("create SystemStatus message");
+
+    let sys_logger = root_logger.new(o!("topic" => "SystemStatus"));
+    let sys_svc_name = service_name.clone();
+    rcal::service_status_loop!(Duration::from_secs(1), {
+        update_message_header!(sys_msg);
+        info!(sys_logger, "sending SystemStatus"; "service" => &sys_svc_name);
+        if let Err(e) = sys_writer.write(&sys_msg) {
+            error!(sys_logger, "SystemStatus write failed"; "service" => &sys_svc_name, "error" => %e);
+        }
+    });
+
+    // ── Periodic ServiceStatus ─────────────────────────────────────────────────
+
+    let mut svc_status_writer =
+        match svc.create_writer::<ServiceStatus_>("ServiceStatus", TopicQos::default()) {
+            Ok(w) => w,
+            Err(e) => {
+                error!(root_logger, "create ServiceStatus writer failed"; "error" => %e);
+                std::process::exit(1);
+            }
+        };
+    let mut svc_status_msg = svc
+        .create_message::<ServiceStatus_>()
+        .expect("create ServiceStatus message");
+
+    let svc_status_logger = root_logger.new(o!("topic" => "ServiceStatus"));
+    let svc_status_svc_name = service_name.clone();
+    rcal::service_status_loop!(Duration::from_secs(1), {
+        update_message_header!(svc_status_msg);
+        info!(svc_status_logger, "sending ServiceStatus"; "service" => &svc_status_svc_name);
+        if let Err(e) = svc_status_writer.write(&svc_status_msg) {
+            error!(svc_status_logger, "ServiceStatus write failed";
+                "service" => &svc_status_svc_name,
+                "error" => %e,
+            );
+        }
+    });
+
+    // ── ServiceStatusDataRequest handler (TestService1 only) ───────────────────
+
+    if svc.status_data_request_enabled() {
+        let resp_writer = match svc.create_writer::<ServiceStatusDataRequestStatus_>(
+            "ServiceStatusDataRequestStatus",
+            TopicQos::default(),
+        ) {
+            Ok(w) => w,
+            Err(e) => {
+                error!(root_logger, "create ServiceStatusDataRequestStatus writer failed"; "error" => %e);
+                std::process::exit(1);
+            }
+        };
+        let resp_msg_template = svc
+            .create_message::<ServiceStatusDataRequestStatus_>()
+            .expect("create ServiceStatusDataRequestStatus message");
+
+        let resp_writer = Arc::new(Mutex::new(resp_writer));
+        let resp_msg = Arc::new(Mutex::new(resp_msg_template));
+        let resp_logger = root_logger.new(o!("topic" => "ServiceStatusDataRequest"));
+        let resp_svc_name = service_name.clone();
+
+        if let Err(e) = svc.create_reader::<ServiceStatusDataRequest_, _>(
+            "ServiceStatusDataRequest",
+            TopicQos::default(),
+            move |_request, _topic| {
+                let mut writer = resp_writer.lock().unwrap();
+                let mut msg = resp_msg.lock().unwrap();
+                update_message_header!(*msg);
+                info!(resp_logger, "ServiceStatusDataRequest received — sending response";
+                    "service" => &resp_svc_name);
+                if let Err(e) = writer.write(&*msg) {
+                    error!(resp_logger, "ServiceStatusDataRequestStatus write failed";
+                        "service" => &resp_svc_name,
+                        "error" => %e,
+                    );
+                }
+            },
+        ) {
+            error!(root_logger, "create_reader for ServiceStatusDataRequest failed"; "error" => %e);
+        }
+    }
+
+    // ── ServiceStatusDataRequestStatus listener ────────────────────────────────
+
+    let resp_status_logger = root_logger.new(o!("topic" => "ServiceStatusDataRequestStatus"));
+    let resp_status_svc_name = service_name.clone();
+    if let Err(e) = svc.create_reader::<ServiceStatusDataRequestStatus_, _>(
+        "ServiceStatusDataRequestStatus",
+        TopicQos::default(),
+        move |_msg, _topic| {
+            info!(resp_status_logger, "received ServiceStatusDataRequestStatus";
+                "service" => &resp_status_svc_name);
+        },
+    ) {
+        warn!(root_logger, "create_reader for ServiceStatusDataRequestStatus failed"; "error" => %e);
+    }
+
+    // ── Send ServiceStatusDataRequests ─────────────────────────────────────────
+
+    let mut req_writer = match svc
+        .create_writer::<ServiceStatusDataRequest_>("ServiceStatusDataRequest", TopicQos::default())
+    {
+        Ok(w) => w,
+        Err(e) => {
+            error!(root_logger, "create ServiceStatusDataRequest writer failed"; "error" => %e);
+            std::process::exit(1);
+        }
+    };
+    let mut req_msg = svc
+        .create_message::<ServiceStatusDataRequest_>()
+        .expect("create ServiceStatusDataRequest message");
+
+    info!(root_logger, "sending {} ServiceStatusDataRequests (delay: {:?})",
+        request_count, request_delay;
+        "service" => &service_name,
+    );
+
+    for i in 0..request_count {
+        tokio::time::sleep(request_delay).await;
+        update_message_header!(req_msg);
+        info!(root_logger, "sending ServiceStatusDataRequest";
+            "service" => &service_name,
+            "i" => i,
+        );
+        if let Err(e) = req_writer.write(&req_msg) {
+            error!(root_logger, "ServiceStatusDataRequest write failed";
+                "service" => &service_name,
+                "error" => %e,
+            );
+        }
+    }
+
+    info!(root_logger, "all requests sent — running until interrupted (Ctrl+C)";
+        "service" => &service_name);
+
+    // Keep status loops alive.
+    tokio::signal::ctrl_c().await.ok();
+
+    if let Err(e) = svc.deactivate() {
+        error!(root_logger, "deactivate failed"; "error" => %e);
+    }
+    info!(root_logger, "service stopped"; "service" => &service_name);
+}

--- a/rcal/rcal_macros/src/lib.rs
+++ b/rcal/rcal_macros/src/lib.rs
@@ -2,10 +2,79 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
 use syn::{
-    Ident, ItemFn, LitBool, LitStr, Token,
+    Ident, ItemFn, ItemStruct, LitBool, LitStr, Token,
     parse::{Parse, ParseStream},
     parse_macro_input,
 };
+
+// ── monitor ──────────────────────────────────────────────────────────────────
+
+/// Injects a `__monitor_mutex: ::std::sync::Mutex<()>` field into a named-field struct.
+///
+/// Pair with `#[guarded]` on methods to implement the monitor pattern — a
+/// single mutex that serialises all externally-callable methods.
+///
+/// The field is private; constructors must initialise it as
+/// `__monitor_mutex: ::std::sync::Mutex::new(())`.
+///
+/// ```ignore
+/// #[rcal_macros::monitor]
+/// pub struct Foo {
+///     x: i32,
+/// }
+///
+/// impl Foo {
+///     pub fn new() -> Self { Self { x: 0, __monitor_mutex: ::std::sync::Mutex::new(()) } }
+///
+///     #[rcal_macros::guarded]
+///     pub fn set_x(&mut self, v: i32) { self.x = v; }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn monitor(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(item as ItemStruct);
+
+    let mutex_field: syn::Field = syn::parse_quote! {
+        __monitor_mutex: ::std::sync::Mutex<()>
+    };
+
+    match &mut input.fields {
+        syn::Fields::Named(fields) => {
+            fields.named.push(mutex_field);
+        }
+        _ => {
+            return syn::Error::new_spanned(
+                &input.ident,
+                "#[monitor] only supports structs with named fields",
+            )
+            .to_compile_error()
+            .into();
+        }
+    }
+
+    quote! { #input }.into()
+}
+
+// ── guarded ───────────────────────────────────────────────────────────────────
+
+/// Prepends `let _monitor_guard = self.__monitor_mutex.lock().unwrap();` to a
+/// method body, acquiring the monitor mutex for the duration of the call.
+///
+/// Apply only to `&self` or `&mut self` methods on a struct annotated with
+/// `#[monitor]`. Do **not** apply to methods that are only called from other
+/// guarded methods — doing so will deadlock (std::sync::Mutex is not reentrant).
+#[proc_macro_attribute]
+pub fn guarded(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut func = parse_macro_input!(item as ItemFn);
+
+    let guard_stmt: syn::Stmt = syn::parse_quote! {
+        let _monitor_guard = self.__monitor_mutex.lock().unwrap();
+    };
+
+    func.block.stmts.insert(0, guard_stmt);
+
+    quote! { #func }.into()
+}
 
 // ── init_test_logger ──────────────────────────────────────────────────────────
 

--- a/rcal/src/calconfig/mod.rs
+++ b/rcal/src/calconfig/mod.rs
@@ -192,6 +192,10 @@ pub struct Service {
     pub topic: Vec<Topic>,
     /// Optional service UUID used to populate the ServiceID field in message headers.
     pub uuid: Option<UUID>,
+    /// Duration string for periodic status message interval (e.g. "1s", "500ms").
+    pub status_delay: Option<String>,
+    /// When true, the service registers a ServiceStatusDataRequest reader and responds automatically.
+    pub service_status_data_request_enable: bool,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]

--- a/rcal/src/lib.rs
+++ b/rcal/src/lib.rs
@@ -8,6 +8,8 @@ pub mod asb;
 pub mod calconfig;
 pub mod logging;
 pub mod qname;
+#[cfg(feature = "service")]
+pub mod service;
 pub mod uci;
 pub mod xs;
 

--- a/rcal/src/service/mod.rs
+++ b/rcal/src/service/mod.rs
@@ -1,0 +1,392 @@
+//! AbstractService trait and default implementation.
+//!
+//! Provides a service-level abstraction above the ASB: lifecycle management,
+//! identity, and convenience passthroughs for creating typed readers/writers.
+//!
+//! ## Specification references
+//! - OMSC-SPC-001 Rev L §5 (service lifecycle)
+//! - OMSC-SPC-008 Rev K §9 (AbstractService)
+
+use std::any::Any;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+
+use slog::{error, info, trace, warn};
+
+use crate::asb::{
+    AbstractServiceBus, AbstractServiceBusCreateMessage, AbstractServiceBusExt, AbstractWriter,
+    MessageListener, TopicQos,
+};
+use crate::calconfig::CalConfig;
+use crate::uci::{CalMessage, CalResult};
+
+// ════════════════════════════════════════════════════════════════════════════
+// ServiceLifecycleState
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Lifecycle state of an AbstractService instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceLifecycleState {
+    /// Service is not active; will not send or receive traffic.
+    Inactive,
+    /// Service is active and processing messages.
+    Active,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AbstractService trait
+// ════════════════════════════════════════════════════════════════════════════
+
+/// High-level service interface sitting above AbstractServiceBus.
+///
+/// Manages service identity, lifecycle state, and provides passthroughs to
+/// the underlying ASB for typed message creation, readers, and writers.
+pub trait AbstractService: Send + Sync {
+    /// The OMS System Identifier for this service.
+    fn system_id(&self) -> &str;
+
+    /// The OMS Service Identifier.
+    fn service_id(&self) -> &str;
+
+    /// The OMS Subsystem Identifiers managed by this service.
+    fn subsystem_ids(&self) -> &[String];
+
+    /// Current lifecycle state.
+    fn lifecycle_state(&self) -> ServiceLifecycleState;
+
+    /// Transitions the service to `Active`. Idempotent — no-op if already active.
+    fn activate(&mut self) -> CalResult<()>;
+
+    /// Transitions the service to `Inactive`. Idempotent — no-op if already inactive.
+    fn deactivate(&mut self) -> CalResult<()>;
+
+    /// Resets the service to its initial state.
+    fn reset(&mut self) -> CalResult<()>;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// CallbackListener
+// ════════════════════════════════════════════════════════════════════════════
+
+struct CallbackListener<M, F> {
+    topic: String,
+    callback: F,
+    _p: PhantomData<M>,
+}
+
+impl<M, F> MessageListener<M> for CallbackListener<M, F>
+where
+    M: CalMessage,
+    F: Fn(Arc<M>, &str) + Send + Sync,
+{
+    fn on_message(&self, message: &Arc<M>) {
+        (self.callback)(Arc::clone(message), &self.topic);
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AbstractServiceImpl
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Concrete AbstractService implementation, generic over the ASB type `A`.
+///
+/// `A` is held directly (not via `dyn AbstractServiceBus`) so that the
+/// generic `AbstractServiceBusExt<M>` methods remain callable at the method level.
+#[rcal_macros::monitor]
+pub struct AbstractServiceImpl<A> {
+    service_id: String,
+    system_id: String,
+    subsystem_ids: Vec<String>,
+    state: ServiceLifecycleState,
+    asb: A,
+    #[allow(dead_code)]
+    config: Arc<CalConfig>,
+    logger: slog::Logger,
+    /// Stores readers so their background receive tasks remain alive.
+    _readers: std::sync::Mutex<Vec<Box<dyn Any + Send>>>,
+}
+
+impl<A: AbstractServiceBus> AbstractServiceImpl<A> {
+    /// Constructs a new `AbstractServiceImpl`.
+    ///
+    /// `subsystem_ids` may be empty; they are stored and returned via
+    /// `AbstractService::subsystem_ids()`.
+    pub fn new(
+        service_id: impl Into<String>,
+        system_id: impl Into<String>,
+        subsystem_ids: Vec<String>,
+        asb: A,
+        config: Arc<CalConfig>,
+        logger: slog::Logger,
+    ) -> Self {
+        let service_id = service_id.into();
+        let system_id = system_id.into();
+        trace!(logger, "AbstractServiceImpl::new";
+            "service_id" => &service_id,
+            "system_id" => &system_id,
+        );
+        Self {
+            service_id,
+            system_id,
+            subsystem_ids,
+            state: ServiceLifecycleState::Inactive,
+            asb,
+            config,
+            logger,
+            _readers: std::sync::Mutex::new(Vec::new()),
+            __monitor_mutex: ::std::sync::Mutex::new(()),
+        }
+    }
+
+    /// Creates a typed message, pre-populated with ASB header defaults.
+    pub fn create_message<M: CalMessage>(&self) -> CalResult<M> {
+        trace!(self.logger, "AbstractServiceImpl::create_message";
+            "service_id" => &self.service_id,
+        );
+        self.asb.create_message::<M>()
+    }
+
+    /// Creates a typed writer for `topic`.
+    pub fn create_writer<M>(
+        &mut self,
+        topic: &str,
+        qos: TopicQos,
+    ) -> CalResult<Box<dyn AbstractWriter<M>>>
+    where
+        M: CalMessage,
+        A: AbstractServiceBusExt<M>,
+    {
+        trace!(self.logger, "AbstractServiceImpl::create_writer";
+            "service_id" => &self.service_id,
+            "topic" => topic,
+        );
+        let _guard = self.__monitor_mutex.lock().unwrap();
+        self.asb.create_writer(topic, qos)
+    }
+
+    /// Creates a typed reader for `topic` with a callback closure.
+    ///
+    /// The callback `F(Arc<M>, &str)` receives each message and the topic name.
+    /// The reader is kept alive for the lifetime of this service instance.
+    pub fn create_reader<M, F>(&mut self, topic: &str, qos: TopicQos, callback: F) -> CalResult<()>
+    where
+        M: CalMessage + 'static,
+        A: AbstractServiceBusExt<M>,
+        F: Fn(Arc<M>, &str) + Send + Sync + 'static,
+    {
+        trace!(self.logger, "AbstractServiceImpl::create_reader";
+            "service_id" => &self.service_id,
+            "topic" => topic,
+        );
+        let _guard = self.__monitor_mutex.lock().unwrap();
+        let mut reader = self.asb.create_reader(topic, qos).map_err(|e| {
+            error!(self.logger, "create_reader failed";
+                "service_id" => &self.service_id,
+                "topic" => topic,
+                "error" => %e,
+            );
+            e
+        })?;
+        let listener: Arc<dyn MessageListener<M>> = Arc::new(CallbackListener {
+            topic: topic.to_string(),
+            callback,
+            _p: PhantomData,
+        });
+        reader.add_listener(listener).map_err(|e| {
+            error!(self.logger, "add_listener failed";
+                "service_id" => &self.service_id,
+                "topic" => topic,
+                "error" => %e,
+            );
+            e
+        })?;
+        self._readers
+            .lock()
+            .unwrap()
+            .push(Box::new(reader) as Box<dyn Any + Send>);
+        Ok(())
+    }
+
+    /// Parses `status_delay` from the service config, returning `None` if absent or unparseable.
+    pub fn status_delay(&self) -> Option<Duration> {
+        let cfg = self.config.get_service(&self.service_id)?;
+        let s = cfg.status_delay.as_deref()?;
+        parse_duration(s)
+            .map_err(|e| {
+                warn!(self.logger, "invalid status_delay, ignored";
+                    "service_id" => &self.service_id,
+                    "value" => s,
+                    "error" => e,
+                );
+            })
+            .ok()
+    }
+
+    /// Returns the value of `service_status_data_request_enable` from config.
+    pub fn status_data_request_enabled(&self) -> bool {
+        self.config
+            .get_service(&self.service_id)
+            .map(|s| s.service_status_data_request_enable)
+            .unwrap_or(false)
+    }
+
+    /// Mutable reference to the underlying ASB.
+    pub fn asb_mut(&mut self) -> &mut A {
+        &mut self.asb
+    }
+}
+
+impl<A: AbstractServiceBus> AbstractService for AbstractServiceImpl<A> {
+    fn system_id(&self) -> &str {
+        &self.system_id
+    }
+
+    fn service_id(&self) -> &str {
+        &self.service_id
+    }
+
+    fn subsystem_ids(&self) -> &[String] {
+        &self.subsystem_ids
+    }
+
+    fn lifecycle_state(&self) -> ServiceLifecycleState {
+        trace!(self.logger, "AbstractService::lifecycle_state";
+            "service_id" => &self.service_id,
+        );
+        let _guard = self.__monitor_mutex.lock().unwrap();
+        self.state
+    }
+
+    fn activate(&mut self) -> CalResult<()> {
+        trace!(self.logger, "AbstractService::activate";
+            "service_id" => &self.service_id,
+        );
+        let _guard = self.__monitor_mutex.lock().unwrap();
+        if self.state == ServiceLifecycleState::Active {
+            warn!(self.logger, "activate called while already active";
+                "service_id" => &self.service_id,
+            );
+            return Ok(());
+        }
+        self.state = ServiceLifecycleState::Active;
+        info!(self.logger, "service activated";
+            "service_id" => &self.service_id,
+        );
+        Ok(())
+    }
+
+    fn deactivate(&mut self) -> CalResult<()> {
+        trace!(self.logger, "AbstractService::deactivate";
+            "service_id" => &self.service_id,
+        );
+        let _guard = self.__monitor_mutex.lock().unwrap();
+        if self.state == ServiceLifecycleState::Inactive {
+            warn!(self.logger, "deactivate called while already inactive";
+                "service_id" => &self.service_id,
+            );
+            return Ok(());
+        }
+        self.state = ServiceLifecycleState::Inactive;
+        info!(self.logger, "service deactivated";
+            "service_id" => &self.service_id,
+        );
+        Ok(())
+    }
+
+    fn reset(&mut self) -> CalResult<()> {
+        trace!(self.logger, "AbstractService::reset";
+            "service_id" => &self.service_id,
+        );
+        Err(crate::uci::CalError::new(
+            crate::uci::CalErrorKind::OperationNotPermitted,
+            format!("reset() not implemented for service '{}'", self.service_id),
+        ))
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// service_status_loop! macro
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Spawns a tokio task that executes `$body` then sleeps `$interval`, forever.
+///
+/// All variables referenced in `$body` are captured by move into the spawned
+/// task — they must be `Send + 'static`. Returns a `tokio::task::JoinHandle<()>`.
+///
+/// # Example
+/// ```ignore
+/// let mut writer = svc.create_writer::<SystemStatus_>("SystemStatus", TopicQos::default())?;
+/// let mut msg = svc.create_message::<SystemStatus_>()?;
+/// service_status_loop!(Duration::from_secs(1), {
+///     rcal::update_message_header!(msg);
+///     if let Err(e) = writer.write(&msg) {
+///         slog::error!(logger, "write failed"; "error" => %e);
+///     }
+/// });
+/// // `writer` and `msg` are now owned by the spawned task.
+/// ```
+#[macro_export]
+macro_rules! service_status_loop {
+    ($interval:expr, $body:block) => {
+        ::tokio::spawn(async move {
+            loop {
+                $body::tokio::time::sleep($interval).await;
+            }
+        })
+    };
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Duration parser
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Parses a human-readable duration string: "1s", "500ms", "2m", etc.
+fn parse_duration(s: &str) -> Result<Duration, &'static str> {
+    if let Some(ms) = s.strip_suffix("ms") {
+        ms.parse::<u64>()
+            .map(Duration::from_millis)
+            .map_err(|_| "invalid milliseconds value")
+    } else if let Some(secs) = s.strip_suffix('s') {
+        secs.parse::<u64>()
+            .map(Duration::from_secs)
+            .map_err(|_| "invalid seconds value")
+    } else if let Some(mins) = s.strip_suffix('m') {
+        mins.parse::<u64>()
+            .map(|m| Duration::from_secs(m * 60))
+            .map_err(|_| "invalid minutes value")
+    } else {
+        Err("unrecognised duration suffix (expected ms, s, or m)")
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Unit tests
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_duration_seconds() {
+        assert_eq!(parse_duration("1s").unwrap(), Duration::from_secs(1));
+        assert_eq!(parse_duration("60s").unwrap(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_parse_duration_milliseconds() {
+        assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn test_parse_duration_minutes() {
+        assert_eq!(parse_duration("2m").unwrap(), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn test_parse_duration_invalid() {
+        assert!(parse_duration("bad").is_err());
+        assert!(parse_duration("1x").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `AbstractService` trait with lifecycle (`activate`/`deactivate`/`reset`), identity, and `ServiceLifecycleState` enum
- Adds `AbstractServiceImpl<A>` generic over ASB type, using monitor pattern for thread safety (`#[monitor]`/`#[guarded]` proc macros in `rcal_macros`)
- Adds `service_status_loop!` macro for spawning periodic status tasks
- Adds `status_delay` and `service_status_data_request_enable` to `calconfig::Service`
- Gates all service code behind `feature = "service"` (default enabled)
- Removes workspace-level `RCAL_XSD_PATH`/`RCAL_SCHEMA_VERSION` overrides so the full `UCI_MessageDefinitions_v2_5_0.xsd` is the default
- Adds `simple_two_service` example: two services on TCP ports 2000/2001, periodic `SystemStatus`/`ServiceStatus` broadcasts, `ServiceStatusDataRequest`/response flow, per-service fixed delays (3s/5s, staggered for visualization)

Closes #32

## Test plan

- [ ] `cargo check --workspace --all-targets` passes
- [ ] `cargo clippy --no-deps` passes
- [ ] `cargo fmt --all` applied
- [ ] `cargo test --workspace --all-targets` passes
- [ ] Manual: open two terminals, run `cargo run -- TestService1 3` and `cargo run -- TestService2 3` from `rcal/examples/simple_two_service/`, observe periodic status messages and request/response exchanges

🤖 Generated with [Claude Code](https://claude.com/claude-code)
