### PR TITLE
feat(asb): gate ZMQ ASB behind zmq feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: rust-clippy-results.sarif
+          sarif_file: rcal/rust-clippy-results.sarif
           wait-for-processing: true
   test:
     runs-on: ubuntu-latest

--- a/rcal/Cargo.toml
+++ b/rcal/Cargo.toml
@@ -27,10 +27,14 @@ slog-json = "2.6.1"
 slog-term = "2.9.2"
 toml = "1.1.4"
 uuid = { version = "1.24.0", features = ["v1", "v3", "v4", "slog", "serde", "rng"] }
-omq-tokio = "0.21.1"
+omq-tokio = { version = "0.21.1", optional = true }
 tokio = { version = "1.53.1", features = ["full"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
 chrono = { version = "0.4.45", features = ["serde"] }
+
+[features]
+zmq = ["dep:omq-tokio"]
+default = ["zmq"]
 
 [build-dependencies]
 quick-xml = { version = "0.37" }
@@ -38,6 +42,7 @@ glob = "0.3.4"
 
 [[bin]]
 name = "zmq_peer_sender"
+required-features = ["zmq"]
 
 [[example]]
 name = "system_status"
@@ -51,14 +56,17 @@ name = "custom_tokio"
 [[test]]
 name = "zmq_radio_dish"
 harness = true
+required-features = ["zmq"]
 
 [[test]]
 name = "zmq_asb_system"
 harness = true
+required-features = ["zmq"]
 
 [[test]]
 name = "zmq_qos"
 harness = true
+required-features = ["zmq"]
 
 [dev-dependencies]
 serde_json = "1.0.151"

--- a/rcal/src/asb/mod.rs
+++ b/rcal/src/asb/mod.rs
@@ -29,7 +29,9 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+#[cfg(feature = "zmq")]
 pub mod zmq;
+#[cfg(feature = "zmq")]
 use zmq::{ZMQ_ASB_ID, ZmqAsb};
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -727,6 +729,7 @@ pub async fn get_asb(
 
     // Construct the implementation without holding the factory lock.
     let instance: AsbInstance = match transport.type_.as_str() {
+        #[cfg(feature = "zmq")]
         ZMQ_ASB_ID => Arc::new(Mutex::new(
             ZmqAsb::new(
                 key.service_identifier.clone(),
@@ -811,6 +814,7 @@ mod tests {
 
     static NEXT_PORT: AtomicU16 = AtomicU16::new(55700);
 
+    #[cfg(feature = "zmq")]
     #[init_test_logger]
     #[tokio::test]
     async fn test_asb_factory_same_key_returns_same_instance() {


### PR DESCRIPTION
## Summary

- Makes `omq-tokio` an optional dependency, activated only with `feature = "zmq"`
- Adds `[features] zmq = ["dep:omq-tokio"]` with `default = ["zmq"]` so existing users are unaffected
- Gates `pub mod zmq`, its imports, the `get_asb` ZMQ match arm, and the factory unit test behind `#[cfg(feature = "zmq")]`
- Adds `required-features = ["zmq"]` to the `zmq_peer_sender` binary and all three ZMQ integration tests so they are skipped cleanly when ZMQ is disabled

Closes #39

## Test plan

- [x] `cargo check --workspace --all-targets` passes (zmq on by default)
- [x] `cargo check --no-default-features` passes (no ZMQ code compiled)
- [x] `cargo clippy --no-deps` passes
- [x] `cargo test --workspace --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
