### PR TITLE
docs: add README.md for all workspace crates

### DIFF
--- a/rcal/README.md
+++ b/rcal/README.md
@@ -1,0 +1,36 @@
+[![CI](https://github.com/tclarke/rcal/actions/workflows/ci.yml/badge.svg)](https://github.com/tclarke/rcal/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/tclarke/rcal/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/tclarke/rcal/actions/workflows/github-code-scanning/codeql)
+[![DevSkim](https://github.com/tclarke/rcal/actions/workflows/devskim.yml/badge.svg)](https://github.com/tclarke/rcal/actions/workflows/devskim.yml)
+
+# rcal
+
+OMS Critical Abstraction Layer (CAL) implementation for Rust. Implements the CERT CAL- requirements with
+inspiration from the CERT CXX- requirements, using idiomatic Rust where it improves on the C++ design.
+
+## Features
+
+- `service` (default) — `AbstractService` lifecycle management and UCI message pub/sub
+- `zmq` (default) — ZMQ-based Abstract Service Bus (`ZmqAsb`) via `omq-tokio`
+
+## Quickstart
+
+Add to `Cargo.toml`:
+
+```toml
+[dependencies]
+rcal = { git = "https://github.com/tclarke/rcal" }
+```
+
+By default rcal generates Rust types from the bundled UCI 2.5.0 XSD at build time. To use a custom schema,
+set `RCAL_SCHEMA_PATH` to your `.xsd` file path (in the environment or in `.cargo/config.toml`).
+
+See the [`examples/`](examples/) directory for usage patterns.
+
+## Crates in this workspace
+
+| Crate | Description |
+|-------|-------------|
+| `rcal` | This crate — core CAL library |
+| [`rcal_macros`](rcal_macros/) | Procedural macros (`#[rcal_main]`, etc.) |
+| [`rcal-xsd-subset`](xsd-subset/) | Dev tool for subsetting UCI XSD files |
+| [`simple_two_service`](examples/simple_two_service/) | Two-service example application |

--- a/rcal/README.md
+++ b/rcal/README.md
@@ -18,13 +18,29 @@ Add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-rcal = { git = "https://github.com/tclarke/rcal" }
+rcal = "1"
 ```
 
-By default rcal generates Rust types from the bundled UCI 2.5.0 XSD at build time. To use a custom schema,
-set `RCAL_SCHEMA_PATH` to your `.xsd` file path (in the environment or in `.cargo/config.toml`).
-
 See the [`examples/`](examples/) directory for usage patterns.
+
+## Build-time configuration
+
+rcal generates Rust UCI message types from an XSD schema at build time. Control this via environment
+variables (set in the shell or in `.cargo/config.toml`):
+
+| Variable | Purpose |
+|----------|---------|
+| `RCAL_CALCONFIG_PATH` | Path to a `CALConfig.toml`. rcal reads the declared topics and generates **only** the UCI types your services actually use, shrinking compile times and binary size. |
+| `RCAL_CALCONFIG_SERVICES` | Comma-separated service names within `RCAL_CALCONFIG_PATH` to further restrict which topics are included. |
+| `RCAL_XSD_PATH` | Path to a custom or subsetted XSD file. Use when you need non-standard types or have pre-subsetted the schema with `rcal-xsd-subset`. Defaults to the bundled UCI 2.5.0 schema. |
+| `RCAL_SCHEMA_VERSION` | Override the version string embedded in generated code (defaults to the `version=` attribute in the XSD). |
+
+Example `.cargo/config.toml`:
+
+```toml
+[env]
+RCAL_CALCONFIG_PATH = "/path/to/CALConfig.toml"
+```
 
 ## Crates in this workspace
 

--- a/rcal/examples/simple_two_service/README.md
+++ b/rcal/examples/simple_two_service/README.md
@@ -1,0 +1,26 @@
+[![CI](https://github.com/tclarke/rcal/actions/workflows/ci.yml/badge.svg)](https://github.com/tclarke/rcal/actions/workflows/ci.yml)
+
+# simple_two_service
+
+Example application demonstrating two rcal services communicating over ZMQ.
+
+Shows:
+
+- `AbstractService` activate/deactivate lifecycle
+- Periodic `SystemStatus` and `ServiceStatus` broadcasting
+- `ServiceStatusDataRequest` / `ServiceStatusDataRequestStatus` request-response pattern
+
+## Running
+
+Open two terminals in the `examples/simple_two_service/` directory and run one command in each:
+
+```sh
+cargo run -- TestService1 3
+cargo run -- TestService2 3
+```
+
+`TestService1` binds on port 2000 and peers to `TestService2` on port 2001. Each sends
+`3` `ServiceStatusDataRequest` messages (configurable via the second argument) then idles
+until interrupted with Ctrl-C.
+
+A `CALConfig.toml` and `ExampleConfig.toml` are included with ready-to-run transport settings.

--- a/rcal/rcal_macros/README.md
+++ b/rcal/rcal_macros/README.md
@@ -1,0 +1,21 @@
+[![CI](https://github.com/tclarke/rcal/actions/workflows/ci.yml/badge.svg)](https://github.com/tclarke/rcal/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/tclarke/rcal/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/tclarke/rcal/actions/workflows/github-code-scanning/codeql)
+
+# rcal_macros
+
+Procedural macros for the [rcal](../) OMS Critical Abstraction Layer library.
+
+## Macros
+
+- `#[rcal_main]` — entry-point macro that initialises the Tokio runtime, builds the CAL config from
+  `CALConfig.toml`, and wires up the root `slog` logger before calling `async fn main`.
+
+## Usage
+
+This crate is a dependency of `rcal` and is re-exported; you typically don't add it directly.
+If you need the macros standalone:
+
+```toml
+[dependencies]
+rcal_macros = { git = "https://github.com/tclarke/rcal", package = "rcal_macros" }
+```

--- a/rcal/rcal_macros/README.md
+++ b/rcal/rcal_macros/README.md
@@ -17,5 +17,5 @@ If you need the macros standalone:
 
 ```toml
 [dependencies]
-rcal_macros = { git = "https://github.com/tclarke/rcal", package = "rcal_macros" }
+rcal_macros = "1"
 ```

--- a/rcal/xsd-subset/README.md
+++ b/rcal/xsd-subset/README.md
@@ -1,0 +1,25 @@
+[![CI](https://github.com/tclarke/rcal/actions/workflows/ci.yml/badge.svg)](https://github.com/tclarke/rcal/actions/workflows/ci.yml)
+
+# rcal-xsd-subset
+
+Developer tool for creating trimmed subsets of UCI XSD schema files. Not part of the `rcal` library
+build pipeline and not published to crates.io.
+
+## Purpose
+
+UCI schema files can be large. This tool strips unused types and elements so that `rcal`'s build script
+generates only the Rust types your application actually needs, reducing compile times and binary size.
+
+## Usage
+
+```sh
+cargo run --manifest-path rcal/xsd-subset/Cargo.toml -- <input.xsd> <output.xsd> [types...]
+```
+
+Set `RCAL_SCHEMA_PATH` to the output file path when building `rcal`:
+
+```toml
+# .cargo/config.toml
+[env]
+RCAL_SCHEMA_PATH = "/path/to/output.xsd"
+```


### PR DESCRIPTION
## Summary
- Adds `README.md` to `rcal`, `rcal_macros`, `rcal-xsd-subset`, and `simple_two_service`
- Each README includes CI badge; security-relevant crates also carry CodeQL badge
- `rcal/README.md` includes a workspace crate index table

## Test plan
- [ ] Verify badges render correctly on GitHub
- [ ] Confirm `simple_two_service` run instructions match `ExampleConfig.toml` port assignments

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)