### PR TITLE
fix: resolve all P0 bugs (#46, #47, #48)

### DIFF
--- a/rcal/src/asb/zmq.rs
+++ b/rcal/src/asb/zmq.rs
@@ -17,6 +17,8 @@ use super::{
 };
 use crate::calconfig::{CalConfig, SerializationFormat, Transport};
 use crate::uci::{CalError, CalErrorKind, CalImplementationErrorKind, CalMessage, CalResult};
+use serde::Deserialize as _;
+use serde::de::IntoDeserializer;
 
 /// ASB identifier string for the ZeroMQ-compatible transport.
 pub const ZMQ_ASB_ID: &str = "zmq";
@@ -356,8 +358,11 @@ impl AbstractServiceBus for ZmqAsb {
         let owner_producer: Vec<_> = sys
             .owner_producer
             .iter()
-            .map(|_s| OwnerProducerChoiceType_::GovernmentIdentifier {
-                inner: OwnerProducerEnum::Usa,
+            .map(|s| {
+                let de: serde::de::value::StrDeserializer<serde::de::value::Error> =
+                    s.as_str().into_deserializer();
+                let inner = OwnerProducerEnum::deserialize(de).unwrap_or(OwnerProducerEnum::Usa);
+                OwnerProducerChoiceType_::GovernmentIdentifier { inner }
             })
             .collect();
         let owner_producer = if owner_producer.is_empty() {

--- a/rcal/src/service/mod.rs
+++ b/rcal/src/service/mod.rs
@@ -331,7 +331,8 @@ macro_rules! service_status_loop {
     ($interval:expr, $body:block) => {
         ::tokio::spawn(async move {
             loop {
-                $body::tokio::time::sleep($interval).await;
+                $body;
+                ::tokio::time::sleep($interval).await;
             }
         })
     };

--- a/rcal/src/xs.rs
+++ b/rcal/src/xs.rs
@@ -132,8 +132,8 @@ impl From<i64> for DateTime {
 
 impl From<DateTime> for i64 {
     fn from(dt: DateTime) -> Self {
-        // Returns i64::MAX for chrono::DateTime values outside the i64-nanosecond range.
-        dt.0.timestamp_nanos_opt().unwrap_or(i64::MAX)
+        dt.0.timestamp_nanos_opt()
+            .expect("DateTime nanosecond timestamp overflows i64 (representable range ~1678–2261)")
     }
 }
 


### PR DESCRIPTION
## Summary

- **#46** `owner_producer` config values ignored, always emitting `USA`: fixed by deserializing each config string to the correct `OwnerProducerEnum` variant via serde, falling back to `Usa` on unknown values.
- **#47** `service_status_loop!` macro generates unparseable syntax: fixed by splitting `$body::tokio::time::sleep(...)` into two separate statements — `$body;` then `::tokio::time::sleep($interval).await;`.
- **#48** `DateTime::from(i64)` silently returns `i64::MAX` on nanosecond overflow: fixed by replacing `unwrap_or(i64::MAX)` with `expect(...)`, making out-of-range timestamps panic loudly instead of lying.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean (excluding pre-existing `simple_two_service` example errors)
- [x] `cargo clippy --no-deps` — clean
- [x] `cargo fmt --all` — applied
- [x] `cargo test --lib` — 54 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)