### PR TITLE
feat: add AbstractServiceBus version and label methods

### DIFF
--- a/rcal/build.rs
+++ b/rcal/build.rs
@@ -9,6 +9,8 @@ fn main() {
     println!("cargo::rerun-if-env-changed=RCAL_XSD_PATH");
     println!("cargo::rerun-if-env-changed=RCAL_SCHEMA_VERSION");
     println!("cargo::rerun-if-env-changed=RCAL_OMS_COMPILER_VERSION");
+    println!("cargo::rerun-if-env-changed=RCAL_ASB_CONNECTION_VERSION");
+    println!("cargo::rerun-if-env-changed=RCAL_OMS_API_VERSION");
     println!("cargo::rerun-if-env-changed=RCAL_CALCONFIG_PATH");
     println!("cargo::rerun-if-env-changed=RCAL_CALCONFIG_SERVICES");
 
@@ -20,6 +22,20 @@ fn main() {
         let compiler_version = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
         println!("cargo::rustc-env=RCAL_OMS_COMPILER_VERSION={compiler_version}");
         eprintln!("OMS compiler version={compiler_version}");
+    }
+
+    if let Ok(asb_ver) = std::env::var("RCAL_ASB_CONNECTION_VERSION") {
+        println!("cargo::rustc-env=RCAL_ASB_CONNECTION_VERSION={asb_ver}");
+    } else {
+        let asb_ver = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        println!("cargo::rustc-env=RCAL_ASB_CONNECTION_VERSION={asb_ver}");
+    }
+
+    if let Ok(api_ver) = std::env::var("RCAL_OMS_API_VERSION") {
+        println!("cargo::rustc-env=RCAL_OMS_API_VERSION={api_ver}");
+    } else {
+        let api_ver = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        println!("cargo::rustc-env=RCAL_OMS_API_VERSION={api_ver}");
     }
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());

--- a/rcal/src/asb/mod.rs
+++ b/rcal/src/asb/mod.rs
@@ -324,6 +324,30 @@ pub trait AbstractServiceBus: Send + Sync {
     /// Version of the OMS Schema Compiler used to generate the CAL.
     fn oms_schema_compiler_version(&self) -> &str;
 
+    /// Human-readable label for the system this CAL instance belongs to.
+    ///
+    /// Sourced from `[system] label` in the CAL configuration file.
+    /// Returns `None` when the label is not configured.
+    ///
+    /// CERT CXX-005424 (`getMySystemLabel()`).
+    fn get_system_label(&self) -> Option<&str>;
+
+    /// Version string identifying this CAL implementation.
+    ///
+    /// Defaults to `<package>/<version>` at build time; override by setting
+    /// the `RCAL_ASB_CONNECTION_VERSION` environment variable during the build.
+    ///
+    /// CERT CXX-011176 (`getAbstractServiceBusConnectionVersion()`).
+    fn get_abstract_service_bus_connection_version(&self) -> &str;
+
+    /// Version string identifying the OMS API against which this CAL was built.
+    ///
+    /// Defaults to `<package>/<version>` at build time; override by setting
+    /// the `RCAL_OMS_API_VERSION` environment variable during the build.
+    ///
+    /// CERT CXX-012694 (`getOMSApiVersion()`).
+    fn get_oms_api_version(&self) -> &str;
+
     // ── Connection Status — Polling ───────────────────────────────────────
 
     /// Returns the current ASB connection status (polling interface, §5.9).

--- a/rcal/src/asb/mod.rs
+++ b/rcal/src/asb/mod.rs
@@ -338,7 +338,7 @@ pub trait AbstractServiceBus: Send + Sync {
     /// the `RCAL_ASB_CONNECTION_VERSION` environment variable during the build.
     ///
     /// CERT CXX-011176 (`getAbstractServiceBusConnectionVersion()`).
-    fn get_abstract_service_bus_connection_version(&self) -> &str;
+    fn get_asb_connection_version(&self) -> &str;
 
     /// Version string identifying the OMS API against which this CAL was built.
     ///

--- a/rcal/src/asb/zmq.rs
+++ b/rcal/src/asb/zmq.rs
@@ -306,6 +306,18 @@ impl AbstractServiceBus for ZmqAsb {
         env!("RCAL_OMS_COMPILER_VERSION")
     }
 
+    fn get_system_label(&self) -> Option<&str> {
+        self.config.system.label.as_deref()
+    }
+
+    fn get_abstract_service_bus_connection_version(&self) -> &str {
+        env!("RCAL_ASB_CONNECTION_VERSION")
+    }
+
+    fn get_oms_api_version(&self) -> &str {
+        env!("RCAL_OMS_API_VERSION")
+    }
+
     fn connection_status(&self) -> &AsbStatus {
         &self.status
     }
@@ -922,6 +934,17 @@ mod tests {
         assert_eq!(a.service_identifier(), "Test Service");
         assert_eq!(a.asb_identifier(), "TestZmq");
         assert_eq!(a.connection_status().state, AsbConnectionState::Normal);
+    }
+
+    #[init_test_logger]
+    #[tokio::test]
+    async fn test_version_and_label_methods() {
+        let a = make_bus(logger).await;
+        // Version strings are non-empty (defaults to package/version).
+        assert!(!a.get_abstract_service_bus_connection_version().is_empty());
+        assert!(!a.get_oms_api_version().is_empty());
+        // Label comes from calconfig_sample.toml.
+        assert_eq!(a.get_system_label(), Some("OMS Test System"));
     }
 
     // ── Transport: inproc ─────────────────────────────────────────────────

--- a/rcal/src/asb/zmq.rs
+++ b/rcal/src/asb/zmq.rs
@@ -310,7 +310,7 @@ impl AbstractServiceBus for ZmqAsb {
         self.config.system.label.as_deref()
     }
 
-    fn get_abstract_service_bus_connection_version(&self) -> &str {
+    fn get_asb_connection_version(&self) -> &str {
         env!("RCAL_ASB_CONNECTION_VERSION")
     }
 
@@ -941,7 +941,7 @@ mod tests {
     async fn test_version_and_label_methods() {
         let a = make_bus(logger).await;
         // Version strings are non-empty (defaults to package/version).
-        assert!(!a.get_abstract_service_bus_connection_version().is_empty());
+        assert!(!a.get_asb_connection_version().is_empty());
         assert!(!a.get_oms_api_version().is_empty());
         // Label comes from calconfig_sample.toml.
         assert_eq!(a.get_system_label(), Some("OMS Test System"));


### PR DESCRIPTION
## Summary

- Adds `get_system_label()` → reads `[system] label` from CAL config (CERT CXX-005424)
- Adds `get_abstract_service_bus_connection_version()` → compile-time `RCAL_ASB_CONNECTION_VERSION` env var, defaults to `<package>/<version>` (CERT CXX-011176)
- Adds `get_oms_api_version()` → compile-time `RCAL_OMS_API_VERSION` env var, defaults to `<package>/<version>` (CERT CXX-012694)
- All three added to `AbstractServiceBus` trait and `ZmqAsb` implementation
- `build.rs` updated to declare the two new env vars and set defaults

Closes #51.

## Test plan

- [ ] `test_version_and_label_methods` passes (verifies version strings non-empty, label matches fixture config)
- [ ] `cargo check --workspace --all-targets` clean
- [ ] `cargo clippy --no-deps` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)