### PR TITLE
feat(asb): add UUID identity methods to AbstractServiceBus (#49)

### DIFF
--- a/rcal/src/asb/mod.rs
+++ b/rcal/src/asb/mod.rs
@@ -288,6 +288,36 @@ pub trait AbstractServiceBus: Send + Sync {
     /// identifies the CAL instance (CERT CAL-005202).
     fn asb_identifier(&self) -> &str;
 
+    /// UUID of the system this CAL instance belongs to (CERT CXX-011168).
+    ///
+    /// Sourced from `[system] uuid` in the CAL configuration file.
+    /// Returns the nil UUID when not configured.
+    fn get_system_uuid(&self) -> UUID;
+
+    /// UUID of the service this CAL instance represents (CERT CXX-011169).
+    ///
+    /// Sourced from `[service.<id>] uuid` in the CAL configuration file.
+    /// Returns `None` when the service UUID is not configured.
+    fn get_service_uuid(&self) -> Option<UUID>;
+
+    /// UUID of the subsystem this service belongs to (CERT CXX-011170).
+    ///
+    /// Sourced from `[service.<id>] subsystem_uuid` in the CAL configuration file.
+    /// Returns `None` when not configured.
+    fn get_subsystem_uuid(&self) -> Option<UUID>;
+
+    /// UUID of the named component (CERT CXX-011171).
+    ///
+    /// Looks up `name` in the `[[service.<id>.components]]` list in the CAL
+    /// configuration file.  Returns `None` when the component is not found.
+    fn get_component_uuid(&self, name: &str) -> Option<UUID>;
+
+    /// UUID of the named capability (CERT CXX-011172).
+    ///
+    /// Looks up `name` in the `[[service.<id>.capabilities]]` list in the CAL
+    /// configuration file.  Returns `None` when the capability is not found.
+    fn get_capability_uuid(&self, name: &str) -> Option<UUID>;
+
     /// Version of the OMS Schema Definition used to generate the CAL.
     fn oms_schema_version(&self) -> &str;
 

--- a/rcal/src/asb/zmq.rs
+++ b/rcal/src/asb/zmq.rs
@@ -270,6 +270,34 @@ impl AbstractServiceBus for ZmqAsb {
         &self.asb_id
     }
 
+    fn get_system_uuid(&self) -> crate::uci::base::UUID {
+        self.config.system.uuid
+    }
+
+    fn get_service_uuid(&self) -> Option<crate::uci::base::UUID> {
+        self.config
+            .get_service(&self.service_name)
+            .and_then(|s| s.uuid)
+    }
+
+    fn get_subsystem_uuid(&self) -> Option<crate::uci::base::UUID> {
+        self.config
+            .get_service(&self.service_name)
+            .and_then(|s| s.subsystem_uuid)
+    }
+
+    fn get_component_uuid(&self, name: &str) -> Option<crate::uci::base::UUID> {
+        self.config
+            .get_service(&self.service_name)
+            .and_then(|s| s.get_component_uuid(name))
+    }
+
+    fn get_capability_uuid(&self, name: &str) -> Option<crate::uci::base::UUID> {
+        self.config
+            .get_service(&self.service_name)
+            .and_then(|s| s.get_capability_uuid(name))
+    }
+
     fn oms_schema_version(&self) -> &str {
         env!("RCAL_SCHEMA_VERSION")
     }
@@ -868,6 +896,19 @@ mod tests {
     }
 
     // ── Basic construction ────────────────────────────────────────────────
+
+    #[init_test_logger]
+    #[tokio::test]
+    async fn test_uuid_identity_methods() {
+        let a = make_bus(logger).await;
+        // System UUID is derived from the port in test_config_on_ports.
+        assert!(!a.get_system_uuid().is_nil());
+        // "Test Service" has no [[service]] entry in the test config → all None.
+        assert_eq!(a.get_service_uuid(), None);
+        assert_eq!(a.get_subsystem_uuid(), None);
+        assert_eq!(a.get_component_uuid("anything"), None);
+        assert_eq!(a.get_capability_uuid("anything"), None);
+    }
 
     #[init_test_logger]
     #[tokio::test]

--- a/rcal/src/calconfig/mod.rs
+++ b/rcal/src/calconfig/mod.rs
@@ -184,6 +184,15 @@ pub struct Transport {
     pub format: SerializationFormat,
 }
 
+/// A name-to-UUID mapping used for components and capabilities (CAL-005203).
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
+pub struct NamedUuid {
+    /// Logical name for the component or capability.
+    pub name: String,
+    /// UUID assigned to this component or capability.
+    pub uuid: UUID,
+}
+
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 #[serde(default)]
 pub struct Service {
@@ -192,10 +201,34 @@ pub struct Service {
     pub topic: Vec<Topic>,
     /// Optional service UUID used to populate the ServiceID field in message headers.
     pub uuid: Option<UUID>,
+    /// Optional subsystem UUID this service belongs to (CAL-005203, CERT CXX-011170).
+    pub subsystem_uuid: Option<UUID>,
+    /// Component UUIDs accessible via this service (CAL-005203, CERT CXX-011171).
+    pub components: Vec<NamedUuid>,
+    /// Capability UUIDs accessible via this service (CAL-005203, CERT CXX-011172).
+    pub capabilities: Vec<NamedUuid>,
     /// Duration string for periodic status message interval (e.g. "1s", "500ms").
     pub status_delay: Option<String>,
     /// When true, the service registers a ServiceStatusDataRequest reader and responds automatically.
     pub service_status_data_request_enable: bool,
+}
+
+impl Service {
+    /// Returns the UUID of the named component, or `None` if not configured.
+    pub fn get_component_uuid(&self, name: &str) -> Option<UUID> {
+        self.components
+            .iter()
+            .find(|c| c.name == name)
+            .map(|c| c.uuid)
+    }
+
+    /// Returns the UUID of the named capability, or `None` if not configured.
+    pub fn get_capability_uuid(&self, name: &str) -> Option<UUID> {
+        self.capabilities
+            .iter()
+            .find(|c| c.name == name)
+            .map(|c| c.uuid)
+    }
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]


### PR DESCRIPTION
## Summary

- Implements CERT CXX-011168–011172 (CAL-005203): five `AbstractServiceBus` methods for retrieving System, Service, Subsystem, Component, and Capability UUIDs
- Extends `Service` config with `subsystem_uuid`, `components`, `capabilities` fields and lookup helpers
- Adds `NamedUuid` struct for name-to-UUID mappings in config
- All five methods implemented in `ZmqAsb`; test `test_uuid_identity_methods` added

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo clippy --no-deps` passes
- [x] `cargo fmt --all` passes
- [x] `cargo test --workspace --all-targets` passes (55 tests)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)