### PR TITLE
feat: separate AbstractServiceBus from CAL layer (#72)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,10 @@ This is a standard cargo layout. all `.rs` and `.toml` files can be used as inpu
  - Additional modules may be added for Rust specific tools, interfaces, and implementations. For example, the abstract service bus (ASB) interfaces will be in the `uci::base` module but ASB implementations can be in `uci::asb` or `asb` modules.
 
 # Starting a task
-When given a goal to complete a specific github issue, first create a branch for the issue.
+When given a goal to complete a specific github issue, first create a branch for the issue and move the issue to "In progress".
 Enter plan mode and come up with a design which implements the issue.
-Always perfor "Coding review and checks" when finished implementing.
-Always update the issue start date and set status to "In Progres" when starting a new task
+Always perform "Coding review and checks" when finished implementing.
+Always update the issue start date and set status to "In Progress" when starting a new task
 Always set the issue status to "In Review" when a PR has been created.
 Always update the end date after the PR has been merged.
 

--- a/design/oms_rust_cal_core.archimate
+++ b/design/oms_rust_cal_core.archimate
@@ -43,9 +43,6 @@
       </element>
     </folder>
     <folder name="Abstract Service Bus" id="f-asb">
-      <element xsi:type="archimate:DataObject" name="CalInstanceConfig" id="e-calinstanceconfig">
-        <documentation>Configuration parameters for initialising a CAL instance. Fields: service_identifier (String, CAL-005201), asb_identifier (String, CAL-005202), network_config_path (PathBuf, Section 4.7). CERTs: CAL-005201, CAL-005202.</documentation>
-      </element>
       <element xsi:type="archimate:DataObject" name="AsbConnectionState" id="e-asbstate">
         <documentation>Enum of ASB connection states per Table 5.9-1: Initializing (optional), Normal (required), Degraded (optional), Inoperable (optional), Failed (required). Provides validate_transition() enforcing the Figure 5.9-2 state machine rules.</documentation>
       </element>
@@ -56,10 +53,21 @@
         <documentation>Trait implemented by CAL Clients to receive ASB connection status change notifications via callback. Method: on_status_change(status: AsbStatus). Called immediately upon registration (CAL-016366), then on every subsequent state change.</documentation>
       </element>
       <element xsi:type="archimate:ApplicationInterface" name="AbstractServiceBus" id="e-asb">
-        <documentation>Primary CAL instance interface (object-safe). Methods: service_id(), uuids() (CAL-005203), connection_status(), register_status_listener() (CAL-016366), unregister_status_listener(), close(). Generic factory methods (create_writer, create_reader) live in the non-object-safe extension trait AbstractServiceBusExt. CERTs: CAL-005201, CAL-005202, CAL-005203, CAL-016366.</documentation>
+        <documentation>Pure transport-layer interface (object-safe). Covers identity (service_identifier, asb_identifier, UUID retrieval — CAL-005203), connection status polling and callback (CAL-016366), and lifecycle (close()). Has no knowledge of message types. CAL-layer concerns (message creation, writers, readers) are in AbstractCal. CERTs: CAL-005201, CAL-005202, CAL-005203, CAL-016366.</documentation>
       </element>
-      <element xsi:type="archimate:ApplicationInterface" name="AbstractServiceBusExt(M)" id="e-asbext">
-        <documentation>Non-object-safe extension trait of AbstractServiceBus providing generic factory methods for typed Writers and Readers. Bounded by M: CalMessage + Serialize + DeserializeOwned at the impl site. Methods: create_writer(topic: &amp;str, qos: TopicQos) returning CalResult(Box(dyn AbstractWriter(M))), create_reader(topic: &amp;str, qos: TopicQos) returning CalResult(Box(dyn AbstractReader(M))). CERTs: CAL-005364, CAL-005374.</documentation>
+    </folder>
+    <folder name="CAL Layer" id="f-cal">
+      <element xsi:type="archimate:DataObject" name="CalInstanceConfig" id="e-calinstanceconfig">
+        <documentation>Configuration parameters for initialising a CAL instance. Fields: service_identifier (String, CAL-005201), asb_identifier (String, CAL-005202), network_config_path (PathBuf, Section 4.7). CERTs: CAL-005201, CAL-005202.</documentation>
+      </element>
+      <element xsi:type="archimate:ApplicationInterface" name="AbstractCal" id="e-abstractcal">
+        <documentation>CAL application-layer interface. Supertrait of AbstractServiceBus — every AbstractCal IS-A AbstractServiceBus. Adds message_header_defaults() which sources system/service config for pre-populating MessageHeader and SecurityInformation fields. Applications obtain an instance via get_cal() (CAL-005201, CAL-005202). CERTs: CAL-005201, CAL-005202, CAL-005203.</documentation>
+      </element>
+      <element xsi:type="archimate:DataObject" name="MessageHeaderDefaults" id="e-msgheaderdefaults">
+        <documentation>Struct carrying default values for MessageHeader and SecurityInformation fields, sourced from CAL configuration. Fields: system_id (UUID), service_id (Option(UUID)), mission_id (Option(UUID)), schema_version (String), mode (MessageModeEnum), classification (ClassificationEnum), owner_producer (Vec(OwnerProducerChoiceType_)).</documentation>
+      </element>
+      <element xsi:type="archimate:ApplicationInterface" name="AbstractCalExt(M)" id="e-asbext">
+        <documentation>Non-object-safe extension trait of AbstractCal providing generic factory methods for typed Writers and Readers. Bounded by M: CalMessage + Serialize + DeserializeOwned at the impl site. Methods: create_writer(topic: &amp;str, qos: TopicQos) returning CalResult(Box(dyn AbstractWriter(M))), create_reader(topic: &amp;str, qos: TopicQos) returning CalResult(Box(dyn AbstractReader(M))). CERTs: CAL-005364, CAL-005374.</documentation>
       </element>
       <element xsi:type="archimate:ApplicationInterface" name="AbstractWriter(M)" id="e-writer">
         <documentation>Trait for a CAL Writer associated with exactly one Client Topic (CAL-005368). M is a CalMessage type. Methods: topic() returning &amp;str, write(message: &amp;M) returning CalResult(()) — errors on topic unavailable (CAL-005369) or resources unavailable (CAL-016043), close() consuming Box(Self). Accepts TopicQos at creation (CAL-005210). CERTs: CAL-005364, CAL-005368, CAL-005369, CAL-016043.</documentation>
@@ -70,8 +78,8 @@
       <element xsi:type="archimate:ApplicationInterface" name="MessageListener(M)" id="e-msglistener">
         <documentation>Callback trait registered with AbstractReader to receive incoming CAL Messages (CAL-005391). Method: on_message(msg: &amp;Arc(M)) — called once per received message with a shared reference (CAL-005392). The reference remains valid for the duration of the call (CAL-016046). CERTs: CAL-005391, CAL-005392, CAL-016046.</documentation>
       </element>
-      <element xsi:type="archimate:ApplicationFunction" name="CalInstanceFactory" id="e-calfactory">
-        <documentation>Platform entry-point function for obtaining a fully initialised CAL instance. Signature: fn(config: CalInstanceConfig) returning CalResult of boxed AbstractServiceBus. CERTs: CAL-005201, CAL-005202.</documentation>
+      <element xsi:type="archimate:ApplicationFunction" name="CalFactory" id="e-calfactory">
+        <documentation>Platform entry-point function get_cal() for obtaining a fully initialised AbstractCal instance. Caches instances per (service_identifier, asb_identifier) key pair. Returns Arc(Mutex(dyn AbstractCal)). CERTs: CAL-005201, CAL-005202.</documentation>
       </element>
     </folder>
     <folder name="QoS" id="f-qos">
@@ -122,11 +130,14 @@
     <element xsi:type="archimate:AssociationRelationship" id="r-bnd-assoc" source="e-bndfield" target="e-calmessage"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-cho-assoc" source="e-choicefield" target="e-calmessage"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-msg-assoc" source="e-calmessage" target="e-calsubmessage"/>
-    <element xsi:type="archimate:AssociationRelationship" id="r-asb-cfg" source="e-asb" target="e-calinstanceconfig"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-asb-cfg" source="e-abstractcal" target="e-calinstanceconfig"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-asb-state" source="e-asb" target="e-asbstate"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-asb-status" source="e-asb" target="e-asbstatus"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-asb-listener" source="e-asb" target="e-asblistener"/>
-    <element xsi:type="archimate:AssociationRelationship" id="r-factory-asb" source="e-calfactory" target="e-asb"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-factory-cal" source="e-calfactory" target="e-abstractcal"/>
+    <!-- AbstractCal extends AbstractServiceBus -->
+    <element xsi:type="archimate:SpecializationRelationship" id="r-cal-extends-asb" source="e-abstractcal" target="e-asb"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-cal-msgheaderdefaults" source="e-abstractcal" target="e-msgheaderdefaults"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-asb-tech" source="e-asb" target="e-asbtech"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-tech-net" source="e-asbtech" target="e-netconfig"/>
     <element xsi:type="archimate:RealizationRelationship" id="id-e6e8c0bba8f24f15a5ab3d1452327d95" source="e-caluuid" target="req-cal-016479"/>
@@ -161,8 +172,8 @@
     <element xsi:type="archimate:RealizationRelationship" id="id-040cc6ac8bb54518bd613c20" source="e-calfactory" target="req-cal-005201"/>
     <element xsi:type="archimate:RealizationRelationship" id="id-efc0d27c03ba4717b3487dfc" source="e-calfactory" target="req-cal-005202"/>
     <element xsi:type="archimate:AssociationRelationship" id="id-11da5b76579a4dc38e718ca402b04fdc" source="e-serviceuuids" target="e-caluuid"/>
-    <!-- AbstractServiceBusExt -->
-    <element xsi:type="archimate:AssociationRelationship" id="r-asbext-asb" source="e-asbext" target="e-asb"/>
+    <!-- AbstractCalExt -->
+    <element xsi:type="archimate:AssociationRelationship" id="r-asbext-asb" source="e-asbext" target="e-abstractcal"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-asbext-writer" source="e-asbext" target="e-writer"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-asbext-reader" source="e-asbext" target="e-reader"/>
     <!-- AbstractWriter -->
@@ -181,6 +192,7 @@
     <element xsi:type="archimate:CompositionRelationship" id="r-qos-tbf" source="e-topicqos" target="e-tbf"/>
     <!-- ZMQ implementation -->
     <element xsi:type="archimate:RealizationRelationship" id="r-zmqasb-real-asb" source="e-zmqasb" target="e-asb"/>
+    <element xsi:type="archimate:RealizationRelationship" id="r-zmqasb-real-cal" source="e-zmqasb" target="e-abstractcal"/>
     <element xsi:type="archimate:RealizationRelationship" id="r-zmqasb-real-asbext" source="e-zmqasb" target="e-asbext"/>
     <element xsi:type="archimate:RealizationRelationship" id="r-zmqwriter-real" source="e-zmqwriter" target="e-writer"/>
     <element xsi:type="archimate:RealizationRelationship" id="r-zmqreader-real" source="e-zmqreader" target="e-reader"/>

--- a/design/oms_rust_cal_core.archimate
+++ b/design/oms_rust_cal_core.archimate
@@ -586,7 +586,7 @@
       </child>
       <child xsi:type="archimate:DiagramObject" id="do-v1-calfactory" archimateElement="e-calfactory">
         <bounds x="380" y="520" width="140" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="con-v1-factory-asb" source="do-v1-calfactory" target="do-v1-asb" archimateRelationship="r-factory-asb"/>
+        <sourceConnection xsi:type="archimate:Connection" id="con-v1-factory-asb" source="do-v1-calfactory" target="do-v1-asb" archimateRelationship="r-factory-cal"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="do-v1-asbtech" targetConnections="con-v1-asb-tech" archimateElement="e-asbtech">
         <bounds x="200" y="620" width="140" height="55"/>
@@ -646,7 +646,7 @@
     <element xsi:type="archimate:ArchimateDiagramModel" name="Detail - Abstract Service Bus" id="v5">
       <child xsi:type="archimate:DiagramObject" id="do-v5-calfactory" archimateElement="e-calfactory">
         <bounds x="504" y="384" width="140" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="con-v5-factory" source="do-v5-calfactory" target="do-v5-asb" archimateRelationship="r-factory-asb"/>
+        <sourceConnection xsi:type="archimate:Connection" id="con-v5-factory" source="do-v5-calfactory" target="do-v5-asb" archimateRelationship="r-factory-cal"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="do-v5-asb" targetConnections="con-v5-factory" archimateElement="e-asb">
         <bounds x="330" y="258" width="163" height="55"/>

--- a/rcal/examples/basic.rs
+++ b/rcal/examples/basic.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use rcal::asb;
+use rcal::cal;
 use slog::{error, info, warn};
 
 #[rcal_macros::rcal_main(config = "examples/CALConfig.toml")]
@@ -18,7 +18,7 @@ async fn main() {
     // `rcal_config` and `root_logger` are injected by the macro.
     let config = Arc::new(rcal_config);
 
-    let bus = match asb::get_asb("basic-example", "default", config, root_logger.clone()).await {
+    let bus = match cal::get_cal("basic-example", "default", config, root_logger.clone()).await {
         Ok(b) => b,
         Err(e) => {
             error!(root_logger, "fatal: failed to create ASB"; "error" => %e);

--- a/rcal/examples/custom_tokio.rs
+++ b/rcal/examples/custom_tokio.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use rcal::asb;
+use rcal::cal;
 use slog::{error, info, warn};
 
 #[rcal_macros::rcal_main(
@@ -25,7 +25,7 @@ async fn main() {
     // `rcal_config` and `my_logger` are injected by the macro.
     let config = Arc::new(rcal_config);
 
-    let bus = match asb::get_asb("custom-example", "default", config, my_logger.clone()).await {
+    let bus = match cal::get_cal("custom-example", "default", config, my_logger.clone()).await {
         Ok(b) => b,
         Err(e) => {
             error!(my_logger, "fatal: failed to create ASB"; "error" => %e);

--- a/rcal/examples/simple_two_service/src/main.rs
+++ b/rcal/examples/simple_two_service/src/main.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use slog::{error, info, o, warn};
 
-use rcal::asb::TopicQos;
+use rcal::cal::TopicQos;
 use rcal::asb::zmq::ZmqAsb;
 use rcal::service::{AbstractService, AbstractServiceImpl};
 use rcal::uci::types::*;

--- a/rcal/examples/system_status.rs
+++ b/rcal/examples/system_status.rs
@@ -11,10 +11,8 @@ use std::time::Duration;
 
 use slog::{error, info};
 
-use rcal::asb::zmq::ZmqAsb;
-use rcal::asb::{
-    AbstractServiceBus, AbstractServiceBusCreateMessage, AbstractServiceBusExt, TopicQos,
-};
+use rcal::asb::{AbstractServiceBus, zmq::ZmqAsb};
+use rcal::cal::{AbstractCalCreateMessage, AbstractCalExt, TopicQos};
 use rcal::uci::CalMessage;
 use rcal::uci::base::UUID;
 use rcal::uci::types::*;
@@ -47,14 +45,14 @@ async fn main() {
     .expect("ASB init failed");
 
     // Create reader before writer so no messages are missed.
-    let mut reader = <ZmqAsb as AbstractServiceBusExt<SystemStatus_>>::create_reader(
+    let mut reader = <ZmqAsb as AbstractCalExt<SystemStatus_>>::create_reader(
         &mut bus,
         TOPIC,
         TopicQos::default(),
     )
     .expect("create_reader failed");
 
-    let mut writer = <ZmqAsb as AbstractServiceBusExt<SystemStatus_>>::create_writer(
+    let mut writer = <ZmqAsb as AbstractCalExt<SystemStatus_>>::create_writer(
         &mut bus,
         TOPIC,
         TopicQos::default(),

--- a/rcal/src/asb/mod.rs
+++ b/rcal/src/asb/mod.rs
@@ -370,7 +370,7 @@ pub trait AbstractServiceBus: Send + Sync {
 
 /// Refreshes the `MessageHeader.Timestamp` field to the current UTC time.
 ///
-/// Accepts any mutable reference to a type that implements [`CalMessage`] with
+/// Accepts any mutable reference to a type that implements [`crate::uci::CalMessage`] with
 /// an accessible `MessageType` (i.e. any generated top-level message wrapper).
 /// No-op for message types that do not expose a `MessageType` interface.
 ///

--- a/rcal/src/asb/mod.rs
+++ b/rcal/src/asb/mod.rs
@@ -1,9 +1,12 @@
-//! Abstract Service Bus (ASB) interface.
+//! Abstract Service Bus (ASB) interface — pure transport layer.
 //!
 //! Provides:
 //!   - Service identity and UUID retrieval (CERT CAL-005203)
-//!   - CAL instance lifecycle management (CERT CAL-005201, CAL-005202)
-//!   - ASB connection status – polling **and** callback (§5.9, CERT CAL-016366)
+//!   - ASB connection state machine and status (§5.9)
+//!   - ASB connection lifecycle and status callbacks (CERT CAL-016366)
+//!
+//! Application-facing concerns (message creation, typed writers/readers, QoS)
+//! live in [`crate::cal`].
 //!
 //! ## Specification references
 //! - OMSC-SPC-001 Rev L §5.3, §5.9, Table 5.9-1/2, Figure 5.9-1/2
@@ -12,27 +15,16 @@
 #![allow(dead_code)]
 #![warn(missing_docs)]
 
-use crate::calconfig::CalConfig;
-use crate::uci::CalMessage;
 use crate::uci::base::UUID;
-use crate::uci::types::{
-    ClassificationEnum, ID_Type as _, MessageModeEnum, OwnerProducerChoiceType_,
-};
 use crate::uci::{CalError, CalErrorKind, CalResult};
-use chrono::Utc;
-use lazy_static::lazy_static;
-use std::collections::HashMap;
 use std::env;
 use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::sync::Arc;
 
 #[cfg(feature = "zmq")]
 pub mod zmq;
-#[cfg(feature = "zmq")]
-use zmq::{ZMQ_ASB_ID, ZmqAsb};
 
 // ════════════════════════════════════════════════════════════════════════════
 // Config helpers
@@ -264,17 +256,17 @@ pub trait AsbStatusListener: Send + Sync {
 // AbstractServiceBus
 // ════════════════════════════════════════════════════════════════════════════
 
-/// Central CAL instance interface — Rust equivalent of the C++
-/// `AbstractServiceBusConnection` abstract class.
+/// Pure transport-layer CAL instance interface (object-safe).
 ///
-/// Each instance is bound to a unique (Service Identifier, ASB Identifier)
-/// pair (CERT CAL-005202) and is obtained via [`get_asb`] (CERT CAL-005201).
+/// Covers identity (service/system UUIDs — CERT CAL-005203), connection status
+/// polling and callback (§5.9, CERT CAL-016366), and lifecycle (close()).
+/// Has no knowledge of message types.
 ///
-/// # Responsibilities
+/// Application-facing concerns (message creation, typed writers/readers, QoS)
+/// are in [`crate::cal::AbstractCal`] which extends this trait.
 ///
-/// 1. **Identity** — expose Service and system UUIDs (CERT CAL-005203).
-/// 2. **Connection Status** — polling *and* callback interfaces (§5.9).
-/// 3. **Lifecycle** — initialisation and graceful shutdown.
+/// # CERT coverage
+/// CAL-005201, CAL-005202, CAL-005203, CAL-016366
 pub trait AbstractServiceBus: Send + Sync {
     /// Returns the [`slog::Logger`] associated with this ASB instance.
     fn get_logger(&self) -> &slog::Logger;
@@ -334,16 +326,10 @@ pub trait AbstractServiceBus: Send + Sync {
 
     /// Version string identifying this CAL implementation.
     ///
-    /// Defaults to `<package>/<version>` at build time; override by setting
-    /// the `RCAL_ASB_CONNECTION_VERSION` environment variable during the build.
-    ///
     /// CERT CXX-011176 (`getAbstractServiceBusConnectionVersion()`).
     fn get_asb_connection_version(&self) -> &str;
 
     /// Version string identifying the OMS API against which this CAL was built.
-    ///
-    /// Defaults to `<package>/<version>` at build time; override by setting
-    /// the `RCAL_OMS_API_VERSION` environment variable during the build.
     ///
     /// CERT CXX-012694 (`getOMSApiVersion()`).
     fn get_oms_api_version(&self) -> &str;
@@ -351,9 +337,6 @@ pub trait AbstractServiceBus: Send + Sync {
     // ── Connection Status — Polling ───────────────────────────────────────
 
     /// Returns the current ASB connection status (polling interface, §5.9).
-    ///
-    /// Executes within the caller's thread.  Safe to call in any state,
-    /// including `Failed`.
     fn connection_status(&self) -> &AsbStatus;
 
     // ── Connection Status — Callback ──────────────────────────────────────
@@ -363,8 +346,7 @@ pub trait AbstractServiceBus: Send + Sync {
     /// `on_status_change` is called **immediately** with the current state
     /// (CERT CAL-016366) and subsequently on every state change.
     ///
-    /// Returns `Err(InvalidState)` when called in the `Failed` state
-    /// (Table 5.9-2: `addListener()` in `Failed` → Error).
+    /// Returns `Err(InvalidState)` when called in the `Failed` state.
     fn register_status_listener(&mut self, listener: Arc<dyn AsbStatusListener>) -> CalResult<()>;
 
     /// Unregisters a previously registered ASB status listener.
@@ -379,439 +361,7 @@ pub trait AbstractServiceBus: Send + Sync {
     // ── Lifecycle ─────────────────────────────────────────────────────────
 
     /// Shuts down the CAL instance and releases all associated resources.
-    ///
-    /// After `close()` returns, all Writers and Readers are invalidated,
-    /// registered listeners will not receive further callbacks, and blocked
-    /// `read()` calls are released with an error.
     fn close(&mut self) -> CalResult<()>;
-
-    // ── Message header defaults ───────────────────────────────────────────
-
-    /// Returns the defaults used to pre-populate `MessageHeader` and
-    /// `SecurityInformation` fields when creating a new message via
-    /// [`AbstractServiceBusCreateMessage::create_message`].
-    fn message_header_defaults(&self) -> MessageHeaderDefaults;
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// MessageHeaderDefaults
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Default values applied to every message created through an ASB.
-///
-/// Sourced from the CAL configuration file (`[system]` and `[service]`
-/// sections) plus the compiled-in schema version string.
-#[derive(Debug, Clone)]
-pub struct MessageHeaderDefaults {
-    /// System UUID for the `MessageHeader.SystemID.UUID` field (required).
-    pub system_id: UUID,
-    /// Optional service UUID for the `MessageHeader.ServiceID.UUID` field.
-    pub service_id: Option<UUID>,
-    /// Optional mission UUID for the `MessageHeader.MissionID.UUID` field.
-    pub mission_id: Option<UUID>,
-    /// Schema version string for `MessageHeader.SchemaVersion`.
-    pub schema_version: String,
-    /// Message mode for `MessageHeader.Mode`.
-    pub mode: MessageModeEnum,
-    /// Classification for `SecurityInformation.Classification`.
-    pub classification: ClassificationEnum,
-    /// OwnerProducer entries for `SecurityInformation.OwnerProducer`.
-    pub owner_producer: Vec<OwnerProducerChoiceType_>,
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// MessageListener
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Callback interface for receiving CAL Messages on a subscribed topic.
-///
-/// Register with [`AbstractReader::add_listener`]. Remove with
-/// [`AbstractReader::remove_listener`] (CERT CAL-005396).
-///
-/// # CAL-005392 — single shared reference
-/// Each registered listener receives the **same** `Arc<M>` exactly once per
-/// received message. The inner `M` is immutable for the full duration of the
-/// handler invocation (CERT CAL-016046).
-///
-/// # Thread safety
-/// The CAL may dispatch `on_message` from an internal receive thread.
-/// Implementations must be `Send + Sync`. If internal mutation is required,
-/// use interior mutability (`Mutex`, `AtomicXxx`, etc.).
-///
-/// # CERT coverage
-/// CAL-005379, CAL-005391, CAL-005392, CAL-005396, CAL-016045, CAL-016046
-pub trait MessageListener<M: CalMessage>: Send + Sync {
-    /// Called once per received message instance (CERT CAL-005392).
-    ///
-    /// Must not block indefinitely — the CAL removes the message from its
-    /// internal buffer only after **all** registered listeners' `on_message`
-    /// calls return (CERT CAL-016045).
-    fn on_message(&self, message: &Arc<M>);
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// AbstractWriter
-// ════════════════════════════════════════════════════════════════════════════
-
-/// A topic-bound CAL message publisher (CERT CAL-005368).
-///
-/// Obtained via [`AbstractServiceBusExt::create_writer`] (CERT CAL-005364).
-///
-/// # Error conditions on `write()`
-/// - `CalErrorKind::TopicUnavailable` — topic connection unavailable (CAL-005369)
-/// - `CalErrorKind::ResourcesUnavailable` — platform resources exhausted (CAL-016043)
-/// - `CalErrorKind::InvalidState` — ASB state prohibits writes (Table 5.9-2)
-///
-/// # CERT coverage
-/// CAL-005364, CAL-005368, CAL-005369, CAL-016043
-pub trait AbstractWriter<M: CalMessage>: Send + Sync {
-    /// The Client Topic string this writer is bound to (CERT CAL-005368).
-    fn topic(&self) -> &str;
-
-    /// Publishes `message` on the bound Client Topic.
-    ///
-    /// Returns `Err(TopicUnavailable)` if the topic is unreachable
-    /// (CERT CAL-005369), `Err(ResourcesUnavailable)` if transport resources
-    /// are exhausted (CERT CAL-016043), or `Err(InvalidState)` if the current
-    /// ASB state prohibits writes (Table 5.9-2).
-    fn write(&mut self, message: &M) -> CalResult<()>;
-
-    /// Shuts down this writer and releases all associated resources.
-    ///
-    /// `Box<Self>` consuming receiver prevents use-after-close at the type
-    /// level, consistent with [`AbstractServiceBus::close`].
-    fn close(self: Box<Self>) -> CalResult<()>;
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// AbstractReader
-// ════════════════════════════════════════════════════════════════════════════
-
-/// A topic-bound CAL message subscriber (CERT CAL-005378).
-///
-/// Obtained via [`AbstractServiceBusExt::create_reader`] (CERT CAL-005374).
-/// The topic connection and message buffering are established at creation
-/// time, before this call returns (CERT CAL-005394, CAL-016044).
-///
-/// # Connection timing (stream-based transports)
-///
-/// For transports that use an asynchronous TCP handshake (e.g. ZeroMQ
-/// RADIO/DISH over TCP), the underlying socket connects in the background.
-/// Messages published in the brief window between `create_reader` returning
-/// and the handshake completing may be missed. Callers requiring reliable
-/// first-message delivery should insert a short delay after creation.
-///
-/// # Callback vs polling — mutually exclusive (CAL-016050)
-///
-/// **Callback mode**: register one or more [`MessageListener`]s via
-/// `add_listener`. Each received message is dispatched to all listeners
-/// exactly once, then removed from the buffer (CAL-016045).
-/// Calling `read` or `read_no_wait` while any listener is registered returns
-/// `Err(OperationNotPermitted)` (CAL-016050).
-///
-/// **Polling mode**: call `read` or `read_no_wait` with no listeners
-/// registered. Each call removes the message from the buffer (CAL-016052).
-///
-/// # CERT coverage
-/// CAL-005374, CAL-005378, CAL-005379, CAL-005380, CAL-005391, CAL-005392,
-/// CAL-005394, CAL-005396, CAL-016044, CAL-016045, CAL-016046, CAL-016049,
-/// CAL-016050, CAL-016052
-pub trait AbstractReader<M: CalMessage>: Send + Sync {
-    /// The Client Topic string this reader is bound to (CERT CAL-005378).
-    fn topic(&self) -> &str;
-
-    // ── Callback interface ────────────────────────────────────────────────
-
-    /// Registers a message listener (CERT CAL-005391).
-    ///
-    /// Zero or more listeners may be registered. Each received message
-    /// is dispatched to every listener exactly once (CERT CAL-005392).
-    /// Once any listener is registered, `read` and `read_no_wait` return
-    /// `Err(OperationNotPermitted)` (CERT CAL-016050).
-    fn add_listener(&mut self, listener: Arc<dyn MessageListener<M>>) -> CalResult<()>;
-
-    /// Unregisters a previously registered listener (CERT CAL-005396).
-    ///
-    /// Identified by `Arc` pointer equality. No-op if not registered.
-    fn remove_listener(&mut self, listener: &Arc<dyn MessageListener<M>>) -> CalResult<()>;
-
-    // ── Polling interface ─────────────────────────────────────────────────
-
-    /// Blocking read — waits until a message arrives or the call is released.
-    ///
-    /// Blocks until:
-    /// 1. A message arrives — returns `Ok(Arc<M>)`, message removed from buffer (CAL-016052).
-    /// 2. `timeout` elapses — returns `Ok(None)`.
-    /// 3. This reader is closed — returns `Err(InvalidState)`.
-    /// 4. The ASB enters `Failed` — returns `Err(AsbFailed)`.
-    ///
-    /// `timeout: None` blocks indefinitely until a message or a close event.
-    ///
-    /// Returns `Err(OperationNotPermitted)` if any listener is registered
-    /// (CERT CAL-016050).
-    ///
-    /// # CERT coverage
-    /// CAL-016049, CAL-016050, CAL-016052
-    fn read(&mut self, timeout: Option<Duration>) -> CalResult<Option<Arc<M>>>;
-
-    /// Non-blocking read — returns a buffered message if one is available.
-    ///
-    /// - `Ok(Some(msg))` — message available; removed from buffer (CAL-016052).
-    /// - `Ok(None)` — buffer empty.
-    /// - `Err(OperationNotPermitted)` — listeners registered (CAL-016050).
-    /// - `Err(InvalidState)` — ASB state prohibits reads (Table 5.9-2).
-    /// - `Err(AsbFailed)` — ASB has permanently failed.
-    ///
-    /// # CERT coverage
-    /// CAL-005380, CAL-016050, CAL-016052
-    fn read_no_wait(&mut self) -> CalResult<Option<Arc<M>>>;
-
-    // ── Lifecycle ─────────────────────────────────────────────────────────
-
-    /// Shuts down this reader and releases all associated resources.
-    ///
-    /// After `close()` returns, registered listeners receive no further
-    /// callbacks and any blocked `read` call returns `Err(InvalidState)`.
-    ///
-    /// `Box<Self>` consuming receiver prevents use-after-close.
-    fn close(self: Box<Self>) -> CalResult<()>;
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// QoS settings
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Reliability policy for a Client Topic (CERT CAL-005434, CAL-016076).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum Reliability {
-    /// Best-effort delivery — messages may be dropped (default).
-    #[default]
-    BestEffort,
-    /// Reliable delivery — unacknowledged messages are retransmitted in order.
-    Reliable,
-}
-
-/// Minimum inter-arrival gap for accepted messages (CERT CAL-005431).
-///
-/// The reader silently drops any message received within `min_separation` of
-/// the previously accepted message.
-#[derive(Debug, Clone)]
-pub struct TimeBasedFilter {
-    /// Minimum time that must elapse between two consecutively accepted messages.
-    pub min_separation: Duration,
-}
-
-/// Maximum lifetime for a buffered message (CERT CAL-005437).
-///
-/// Messages older than `max_age` are removed from the receive buffer.
-#[derive(Debug, Clone)]
-pub struct Expiration {
-    /// Age after which a buffered message is discarded.
-    pub max_age: Duration,
-}
-
-/// Bounded message buffer (CERT CAL-005444, CAL-005445, CAL-015746, CAL-016079).
-///
-/// Used for both the writer-side send buffer (`TopicQos::writer_buffer`) and
-/// the reader-side receive buffer (`TopicQos::reader_buffer`). When the count
-/// of buffered messages exceeds `max_messages`, the oldest is dropped.
-#[derive(Debug, Clone)]
-pub struct MessageBuffer {
-    /// Maximum number of messages held in the buffer before the oldest is dropped.
-    pub max_messages: usize,
-}
-
-/// Aggregate Quality of Service settings for a Client Topic (CERT CAL-005210).
-///
-/// Pass to [`AbstractServiceBusExt::create_writer`] or
-/// [`AbstractServiceBusExt::create_reader`] at creation time. The default
-/// value selects best-effort reliability with no filtering, no expiration, and
-/// unbounded buffers.
-#[derive(Debug, Clone, Default)]
-pub struct TopicQos {
-    /// Delivery reliability policy (default: `BestEffort`).
-    pub reliability: Reliability,
-    /// Time-based filter applied on the reader side; `None` disables filtering.
-    pub time_based_filter: Option<TimeBasedFilter>,
-    /// Message lifetime on the reader's receive buffer; `None` disables expiry.
-    pub expiration: Option<Expiration>,
-    /// Writer-side send buffer limit; `None` means unbounded.
-    pub writer_buffer: Option<MessageBuffer>,
-    /// Reader-side receive buffer limit; `None` means unbounded.
-    pub reader_buffer: Option<MessageBuffer>,
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// AbstractServiceBusExt
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Extension trait adding typed factory methods to [`AbstractServiceBus`].
-///
-/// Separated so that `AbstractServiceBus` remains object-safe —
-/// `dyn AbstractServiceBus` can still be stored in `Arc<Mutex<...>>`.
-/// Factory methods are called through a concrete or generic reference.
-///
-/// # CERT coverage
-/// CAL-005364 (`create_writer`), CAL-005374 (`create_reader`)
-pub trait AbstractServiceBusExt<M: CalMessage>: AbstractServiceBus {
-    /// Creates a [`AbstractWriter`] bound to `topic` with the given QoS
-    /// settings (CERT CAL-005364, CAL-005210).
-    ///
-    /// Returns `Err(TopicUnavailable)` if `topic` is not a valid Client Topic
-    /// for this service (CERT CAL-005368, CAL-005369).
-    fn create_writer(
-        &mut self,
-        topic: &str,
-        qos: TopicQos,
-    ) -> CalResult<Box<dyn AbstractWriter<M>>>;
-
-    /// Creates an [`AbstractReader`] bound to `topic` with the given QoS
-    /// settings (CERT CAL-005374, CAL-005210).
-    ///
-    /// The topic connection and message buffering are established before this
-    /// returns (CERT CAL-005394, CAL-016044).
-    ///
-    /// Returns `Err(TopicUnavailable)` if `topic` is not a valid Client Topic
-    /// (CERT CAL-005378).
-    fn create_reader(
-        &mut self,
-        topic: &str,
-        qos: TopicQos,
-    ) -> CalResult<Box<dyn AbstractReader<M>>>;
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// AbstractServiceBusCreateMessage
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Extension trait that adds typed message creation to any [`AbstractServiceBus`].
-///
-/// Implemented as a blanket impl over all `AbstractServiceBus` types so that
-/// transport implementations do not need to duplicate this logic.
-///
-/// Use this instead of constructing message types directly — generated structs
-/// have no public constructors (CERT CAL-016035).
-pub trait AbstractServiceBusCreateMessage {
-    /// Creates a default-initialised instance of message type `M`.
-    ///
-    /// Equivalent to the C++ `<Type>::create(asb)` static factory.
-    fn create_message<M: CalMessage>(&self) -> CalResult<M>;
-}
-
-impl<T: AbstractServiceBus> AbstractServiceBusCreateMessage for T {
-    fn create_message<M: CalMessage>(&self) -> CalResult<M> {
-        let mut msg = M::cal_create();
-        if let Some(mt) = msg.as_message_type_mut() {
-            let defaults = self.message_header_defaults();
-            let hdr = mt.message_header_mut();
-            *hdr.system_id_mut().uuid_mut() = defaults.system_id;
-            *hdr.schema_version_mut() = defaults.schema_version;
-            *hdr.mode_mut() = defaults.mode;
-            *hdr.timestamp_mut() = Utc::now().into();
-            // Optional fields can only be set if already initialized (trait returns Option<&mut>).
-            // service_id and mission_id are set here only if already Some in the message.
-            if let (Some(sid), Some(sfield)) = (defaults.service_id, hdr.service_id_mut()) {
-                *sfield.uuid_mut() = sid;
-            }
-            if let (Some(mid), Some(mfield)) = (defaults.mission_id, hdr.mission_id_mut()) {
-                *mfield.uuid_mut() = mid;
-            }
-            let sec = mt.security_information_mut();
-            *sec.classification_mut() = defaults.classification;
-            let op = sec.owner_producer_mut();
-            op.clear();
-            op.extend(defaults.owner_producer);
-        }
-        Ok(msg)
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// Factory
-// ════════════════════════════════════════════════════════════════════════════
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct AsbKey {
-    service_identifier: String,
-    asb_identifier: String,
-}
-
-type AsbInstance = Arc<Mutex<dyn AbstractServiceBus>>;
-type AsbFactoryMap = HashMap<AsbKey, AsbInstance>;
-
-lazy_static! {
-    static ref ASB_FACTORY: tokio::sync::Mutex<AsbFactoryMap> =
-        tokio::sync::Mutex::new(AsbFactoryMap::new());
-}
-
-/// Returns the [`AbstractServiceBus`] instance for `(service_identifier,
-/// asb_identifier)`, creating it if it does not yet exist.
-///
-/// Satisfies CERT CAL-005201 (mechanism to obtain a fully initialised CAL
-/// instance) and CERT CAL-005202 (one instance per unique key pair).
-///
-/// Returns `Err(InitializationFailure)` when no matching (or default)
-/// transport is configured, or when the underlying constructor fails.
-pub async fn get_asb(
-    service_identifier: impl Into<String>,
-    asb_identifier: impl Into<String>,
-    config: Arc<CalConfig>,
-    logger: slog::Logger,
-) -> CalResult<AsbInstance> {
-    let key = AsbKey {
-        service_identifier: service_identifier.into(),
-        asb_identifier: asb_identifier.into(),
-    };
-
-    // Hold the factory lock for the entire construction to prevent concurrent
-    // callers from constructing duplicate instances that bind the same socket.
-    let mut map = ASB_FACTORY.lock().await;
-
-    if let Some(existing) = map.get(&key) {
-        return Ok(Arc::clone(existing));
-    }
-
-    let transport = config
-        .get_transport(&key.asb_identifier)
-        .or_else(|| {
-            config
-                .system
-                .default_transport
-                .as_ref()
-                .and_then(|def| config.get_transport(def))
-        })
-        .ok_or_else(|| {
-            CalError::new(
-                CalErrorKind::InitializationFailure,
-                format!(
-                    "No transport configured for '{}' and no default_transport available.",
-                    key.asb_identifier
-                ),
-            )
-        })?;
-
-    let instance: AsbInstance = match transport.type_.as_str() {
-        #[cfg(feature = "zmq")]
-        ZMQ_ASB_ID => Arc::new(Mutex::new(
-            ZmqAsb::new(
-                key.service_identifier.clone(),
-                key.asb_identifier.clone(),
-                logger,
-                Arc::clone(&config),
-                transport,
-            )
-            .await?,
-        )),
-        other => {
-            return Err(CalError::new(
-                CalErrorKind::InitializationFailure,
-                format!("Unknown ASB transport type: '{other}'."),
-            ));
-        }
-    };
-
-    map.insert(key, Arc::clone(&instance));
-    Ok(instance)
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -850,78 +400,15 @@ pub(crate) static NEXT_TEST_PORT: std::sync::atomic::AtomicU16 =
 #[cfg(test)]
 mod trait_object_safety {
     use super::*;
-    use crate::uci::CalMessage;
 
-    struct Ping;
-    impl CalMessage for Ping {
-        fn message_type_name() -> crate::QName {
-            "test.Ping".into()
-        }
-        fn cal_create() -> Self {
-            Self
-        }
-    }
-
-    // Compile-only assertions — fail at definition site if any trait is not object-safe.
+    // Compile-only assertion — fails at definition site if AbstractServiceBus is not object-safe.
     #[allow(dead_code)]
-    type _W = Box<dyn AbstractWriter<Ping>>;
-    #[allow(dead_code)]
-    type _R = Box<dyn AbstractReader<Ping>>;
-    #[allow(dead_code)]
-    type _L = Arc<dyn MessageListener<Ping>>;
+    type _Asb = Arc<std::sync::Mutex<dyn AbstractServiceBus>>;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::calconfig::{get_test_config_path, parse_config_from_file};
-    use rcal_macros::init_test_logger;
-    use std::sync::atomic::Ordering;
-
-    #[cfg(feature = "zmq")]
-    #[init_test_logger]
-    #[tokio::test]
-    async fn test_asb_factory_same_key_returns_same_instance() {
-        let p1 = super::NEXT_TEST_PORT.fetch_add(1, Ordering::SeqCst);
-        let p2 = super::NEXT_TEST_PORT.fetch_add(1, Ordering::SeqCst);
-        let config = zmq::test_config_on_ports(&[p1, p2]);
-
-        let a = get_asb("test_svc", "TestZmq", Arc::clone(&config), logger.clone())
-            .await
-            .expect("first get_asb must succeed");
-        let b = get_asb("test_svc", "TestZmq", Arc::clone(&config), logger.clone())
-            .await
-            .expect("second get_asb must succeed");
-        let c = get_asb(
-            "test_svc_2",
-            "TestZmq2",
-            Arc::clone(&config),
-            logger.clone(),
-        )
-        .await
-        .expect("different service must succeed");
-
-        // Same (service, asb) key → same Arc (CERT CAL-005202)
-        assert!(Arc::ptr_eq(&a, &b), "same key should return the same Arc");
-        // Different service key → different Arc
-        assert!(
-            !Arc::ptr_eq(&a, &c),
-            "different service key must be a distinct instance"
-        );
-    }
-
-    #[init_test_logger]
-    #[tokio::test]
-    async fn test_asb_factory_unknown_transport_returns_err() {
-        let no_default_config = Arc::new(
-            parse_config_from_file(&get_test_config_path("calconfig_no_default.toml")).unwrap(),
-        );
-        assert!(
-            get_asb("svc", "dummy", no_default_config, logger)
-                .await
-                .is_err()
-        );
-    }
 
     #[tokio::test]
     async fn test_state_display_does_not_recurse() {

--- a/rcal/src/asb/zmq.rs
+++ b/rcal/src/asb/zmq.rs
@@ -11,9 +11,10 @@ use std::time::{Duration, Instant};
 
 use omq_tokio::{Endpoint, Message, Options, Socket, SocketType};
 
-use super::{
-    AbstractReader, AbstractServiceBus, AbstractServiceBusExt, AbstractWriter, AsbConnectionState,
-    AsbStatus, AsbStatusListener, MessageHeaderDefaults, MessageListener, TopicQos,
+use super::{AbstractServiceBus, AsbConnectionState, AsbStatus, AsbStatusListener};
+use crate::cal::{
+    AbstractCal, AbstractCalExt, AbstractReader, AbstractWriter, MessageHeaderDefaults,
+    MessageListener, TopicQos,
 };
 use crate::calconfig::{CalConfig, SerializationFormat, Transport};
 use crate::uci::{CalError, CalErrorKind, CalImplementationErrorKind, CalMessage, CalResult};
@@ -219,7 +220,7 @@ impl ZmqAsb {
 
     /// Registers a remote RADIO URI whose messages this ASB should receive.
     ///
-    /// Readers created via [`AbstractServiceBusExt::create_reader`] will
+    /// Readers created via [`AbstractCalExt::create_reader`] will
     /// connect their DISH sockets to every registered peer URI.  If no peers
     /// are registered the DISH connects to this ASB's own `transport_uri`,
     /// which is the correct behaviour for single-process tests.
@@ -371,7 +372,13 @@ impl AbstractServiceBus for ZmqAsb {
         self.write_tx = None;
         Ok(())
     }
+}
 
+// ════════════════════════════════════════════════════════════════════════════
+// AbstractCal implementation
+// ════════════════════════════════════════════════════════════════════════════
+
+impl AbstractCal for ZmqAsb {
     fn message_header_defaults(&self) -> MessageHeaderDefaults {
         use crate::uci::types::{
             ClassificationEnum, MessageModeEnum, OwnerProducerChoiceType_, OwnerProducerEnum,
@@ -627,10 +634,10 @@ impl<M: CalMessage + serde::de::DeserializeOwned> AbstractReader<M> for ZmqReade
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-// AbstractServiceBusExt implementation
+// AbstractCalExt implementation
 // ════════════════════════════════════════════════════════════════════════════
 
-impl<M> AbstractServiceBusExt<M> for ZmqAsb
+impl<M> AbstractCalExt<M> for ZmqAsb
 where
     M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
 {
@@ -821,7 +828,7 @@ where
 
 /// Builds a [`CalConfig`] with one TCP transport entry per port in `ports`.
 #[cfg(test)]
-pub(super) fn test_config_on_ports(ports: &[u16]) -> Arc<CalConfig> {
+pub(crate) fn test_config_on_ports(ports: &[u16]) -> Arc<CalConfig> {
     use crate::calconfig;
     use crate::uci::base::UUID;
     const BASE_UUID: &str = "6ef79d81-8a79-4750-9c6a-e5e50a30f81b";
@@ -865,6 +872,7 @@ pub(super) fn test_config_inproc(name: &str) -> Arc<CalConfig> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cal::{Expiration, MessageBuffer, TimeBasedFilter};
     use omq_tokio::endpoint::Host;
     use omq_tokio::{Endpoint, Message, MonitorEvent, Options, Socket, SocketType};
     use rcal_macros::init_test_logger;
@@ -1246,7 +1254,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
+        let result = <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1267,7 +1275,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(
+        let result = <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1289,7 +1297,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
+            <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(
                 &mut asb,
                 "test.topic",
                 TopicQos::default(),
@@ -1322,7 +1330,7 @@ mod tests {
         .unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let mut writer = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
+        let mut writer = <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1378,7 +1386,7 @@ mod tests {
         .unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let mut writer = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
+        let mut writer = <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1417,7 +1425,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut reader = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(
+        let mut reader = <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1428,7 +1436,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Send a message via the RADIO (through ZmqAsb's write task)
-        let mut writer = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
+        let mut writer = <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1460,7 +1468,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut reader = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(
+        let mut reader = <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1483,7 +1491,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut reader = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(
+        let mut reader = <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1507,7 +1515,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut reader = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(
+        let mut reader = <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1544,7 +1552,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut reader = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(
+        let mut reader = <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1570,7 +1578,7 @@ mod tests {
         // Allow DISH to connect
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let mut writer = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
+        let mut writer = <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1610,7 +1618,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut reader = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(
+        let mut reader = <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1649,17 +1657,17 @@ mod tests {
             .unwrap();
 
         let qos = TopicQos {
-            time_based_filter: Some(super::super::TimeBasedFilter {
+            time_based_filter: Some(TimeBasedFilter {
                 min_separation: Duration::from_millis(200),
             }),
             ..TopicQos::default()
         };
         let mut reader =
-            <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(&mut asb, "test.topic", qos)
+            <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(&mut asb, "test.topic", qos)
                 .unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let mut writer = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
+        let mut writer = <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1703,17 +1711,17 @@ mod tests {
             .unwrap();
 
         let qos = TopicQos {
-            expiration: Some(super::super::Expiration {
+            expiration: Some(Expiration {
                 max_age: Duration::from_millis(50),
             }),
             ..TopicQos::default()
         };
         let mut reader =
-            <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(&mut asb, "test.topic", qos)
+            <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(&mut asb, "test.topic", qos)
                 .unwrap();
         tokio::time::sleep(Duration::from_millis(30)).await;
 
-        let mut writer = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
+        let mut writer = <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1746,15 +1754,15 @@ mod tests {
             .unwrap();
 
         let qos = TopicQos {
-            reader_buffer: Some(super::super::MessageBuffer { max_messages: 2 }),
+            reader_buffer: Some(MessageBuffer { max_messages: 2 }),
             ..TopicQos::default()
         };
         let mut reader =
-            <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(&mut asb, "test.topic", qos)
+            <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(&mut asb, "test.topic", qos)
                 .unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        let mut writer = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
+        let mut writer = <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1796,17 +1804,14 @@ mod tests {
         let _hold = gate.lock().await;
 
         let writer_qos = TopicQos {
-            writer_buffer: Some(super::super::MessageBuffer { max_messages: 2 }),
+            writer_buffer: Some(MessageBuffer { max_messages: 2 }),
             ..TopicQos::default()
         };
-        let mut writer = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
-            &mut asb,
-            "test.topic",
-            writer_qos,
-        )
-        .unwrap();
+        let mut writer =
+            <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(&mut asb, "test.topic", writer_qos)
+                .unwrap();
 
-        let mut reader = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_reader(
+        let mut reader = <ZmqAsb as AbstractCalExt<TestMsg>>::create_reader(
             &mut asb,
             "test.topic",
             TopicQos::default(),
@@ -1851,15 +1856,12 @@ mod tests {
         let _hold = gate.lock().await; // freeze the forwarding task
 
         let writer_qos = TopicQos {
-            writer_buffer: Some(super::super::MessageBuffer { max_messages: 10 }),
+            writer_buffer: Some(MessageBuffer { max_messages: 10 }),
             ..TopicQos::default()
         };
-        let mut writer = <ZmqAsb as AbstractServiceBusExt<TestMsg>>::create_writer(
-            &mut asb,
-            "test.topic",
-            writer_qos,
-        )
-        .unwrap();
+        let mut writer =
+            <ZmqAsb as AbstractCalExt<TestMsg>>::create_writer(&mut asb, "test.topic", writer_qos)
+                .unwrap();
 
         writer
             .write(&TestMsg {

--- a/rcal/src/bin/zmq_peer_sender.rs
+++ b/rcal/src/bin/zmq_peer_sender.rs
@@ -10,9 +10,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rcal::QName;
+use rcal::asb::AbstractServiceBus;
 use rcal::asb::zmq::ZmqAsb;
 use rcal::uci::CalMessage;
-use rcal::uci::base::{AbstractServiceBus, AbstractServiceBusExt, TopicQos, UUID};
+use rcal::uci::base::{AbstractCalExt, TopicQos, UUID};
 
 #[derive(serde::Serialize, serde::Deserialize)]
 struct IntMsg {
@@ -57,12 +58,9 @@ async fn main() {
         .await
         .unwrap();
 
-    let mut writer = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_writer(
-        &mut bus,
-        "data",
-        TopicQos::default(),
-    )
-    .unwrap();
+    let mut writer =
+        <ZmqAsb as AbstractCalExt<IntMsg>>::create_writer(&mut bus, "data", TopicQos::default())
+            .unwrap();
 
     // Allow receiver process to connect before publishing.
     // ponytail: fixed delay, use a ready-signal if startup variance matters

--- a/rcal/src/cal/mod.rs
+++ b/rcal/src/cal/mod.rs
@@ -1,0 +1,473 @@
+//! CAL layer interfaces — application-facing traits above the pure transport ASB.
+//!
+//! ## Specification references
+//! - OMSC-SPC-001 Rev L §5.4–5.8 (topics, messages, writers, readers, QoS)
+//! - OMSC-SPC-001 Rev L §5.3 (CAL initialisation, CAL-005201, CAL-005202)
+
+#![allow(dead_code)]
+#![warn(missing_docs)]
+
+use crate::asb::AbstractServiceBus;
+use crate::calconfig::CalConfig;
+use crate::uci::CalMessage;
+use crate::uci::base::UUID;
+use crate::uci::types::{
+    ClassificationEnum, ID_Type as _, MessageModeEnum, OwnerProducerChoiceType_,
+};
+use crate::uci::{CalError, CalErrorKind, CalResult};
+use chrono::Utc;
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[cfg(feature = "zmq")]
+use crate::asb::zmq::{ZMQ_ASB_ID, ZmqAsb};
+
+// ════════════════════════════════════════════════════════════════════════════
+// MessageHeaderDefaults
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Default values applied to every message created through a CAL instance.
+///
+/// Sourced from the CAL configuration file (`[system]` and `[service]`
+/// sections) plus the compiled-in schema version string.
+#[derive(Debug, Clone)]
+pub struct MessageHeaderDefaults {
+    /// System UUID for the `MessageHeader.SystemID.UUID` field (required).
+    pub system_id: UUID,
+    /// Optional service UUID for the `MessageHeader.ServiceID.UUID` field.
+    pub service_id: Option<UUID>,
+    /// Optional mission UUID for the `MessageHeader.MissionID.UUID` field.
+    pub mission_id: Option<UUID>,
+    /// Schema version string for `MessageHeader.SchemaVersion`.
+    pub schema_version: String,
+    /// Message mode for `MessageHeader.Mode`.
+    pub mode: MessageModeEnum,
+    /// Classification for `SecurityInformation.Classification`.
+    pub classification: ClassificationEnum,
+    /// OwnerProducer entries for `SecurityInformation.OwnerProducer`.
+    pub owner_producer: Vec<OwnerProducerChoiceType_>,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// MessageListener
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Callback interface for receiving CAL Messages on a subscribed topic.
+///
+/// Register with [`AbstractReader::add_listener`]. Remove with
+/// [`AbstractReader::remove_listener`] (CERT CAL-005396).
+///
+/// # CAL-005392 — single shared reference
+/// Each registered listener receives the **same** `Arc<M>` exactly once per
+/// received message. The inner `M` is immutable for the full duration of the
+/// handler invocation (CERT CAL-016046).
+///
+/// # Thread safety
+/// The CAL may dispatch `on_message` from an internal receive thread.
+/// Implementations must be `Send + Sync`. If internal mutation is required,
+/// use interior mutability (`Mutex`, `AtomicXxx`, etc.).
+///
+/// # CERT coverage
+/// CAL-005379, CAL-005391, CAL-005392, CAL-005396, CAL-016045, CAL-016046
+pub trait MessageListener<M: CalMessage>: Send + Sync {
+    /// Called once per received message instance (CERT CAL-005392).
+    ///
+    /// Must not block indefinitely — the CAL removes the message from its
+    /// internal buffer only after **all** registered listeners' `on_message`
+    /// calls return (CERT CAL-016045).
+    fn on_message(&self, message: &Arc<M>);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AbstractWriter
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A topic-bound CAL message publisher (CERT CAL-005368).
+///
+/// Obtained via [`AbstractCalExt::create_writer`] (CERT CAL-005364).
+///
+/// # Error conditions on `write()`
+/// - `CalErrorKind::TopicUnavailable` — topic connection unavailable (CAL-005369)
+/// - `CalErrorKind::ResourcesUnavailable` — platform resources exhausted (CAL-016043)
+/// - `CalErrorKind::InvalidState` — ASB state prohibits writes (Table 5.9-2)
+///
+/// # CERT coverage
+/// CAL-005364, CAL-005368, CAL-005369, CAL-016043
+pub trait AbstractWriter<M: CalMessage>: Send + Sync {
+    /// The Client Topic string this writer is bound to (CERT CAL-005368).
+    fn topic(&self) -> &str;
+
+    /// Publishes `message` on the bound Client Topic.
+    ///
+    /// Returns `Err(TopicUnavailable)` if the topic is unreachable
+    /// (CERT CAL-005369), `Err(ResourcesUnavailable)` if transport resources
+    /// are exhausted (CERT CAL-016043), or `Err(InvalidState)` if the current
+    /// ASB state prohibits writes (Table 5.9-2).
+    fn write(&mut self, message: &M) -> CalResult<()>;
+
+    /// Shuts down this writer and releases all associated resources.
+    ///
+    /// `Box<Self>` consuming receiver prevents use-after-close at the type
+    /// level, consistent with [`AbstractServiceBus::close`].
+    fn close(self: Box<Self>) -> CalResult<()>;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AbstractReader
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A topic-bound CAL message subscriber (CERT CAL-005378).
+///
+/// Obtained via [`AbstractCalExt::create_reader`] (CERT CAL-005374).
+/// The topic connection and message buffering are established at creation
+/// time, before this call returns (CERT CAL-005394, CAL-016044).
+///
+/// # Callback vs polling — mutually exclusive (CAL-016050)
+///
+/// **Callback mode**: register one or more [`MessageListener`]s via
+/// `add_listener`. Each received message is dispatched to all listeners
+/// exactly once, then removed from the buffer (CAL-016045).
+/// Calling `read` or `read_no_wait` while any listener is registered returns
+/// `Err(OperationNotPermitted)` (CAL-016050).
+///
+/// **Polling mode**: call `read` or `read_no_wait` with no listeners
+/// registered. Each call removes the message from the buffer (CAL-016052).
+///
+/// # CERT coverage
+/// CAL-005374, CAL-005378, CAL-005379, CAL-005380, CAL-005391, CAL-005392,
+/// CAL-005394, CAL-005396, CAL-016044, CAL-016045, CAL-016046, CAL-016049,
+/// CAL-016050, CAL-016052
+pub trait AbstractReader<M: CalMessage>: Send + Sync {
+    /// The Client Topic string this reader is bound to (CERT CAL-005378).
+    fn topic(&self) -> &str;
+
+    // ── Callback interface ────────────────────────────────────────────────
+
+    /// Registers a message listener (CERT CAL-005391).
+    fn add_listener(&mut self, listener: Arc<dyn MessageListener<M>>) -> CalResult<()>;
+
+    /// Unregisters a previously registered listener (CERT CAL-005396).
+    fn remove_listener(&mut self, listener: &Arc<dyn MessageListener<M>>) -> CalResult<()>;
+
+    // ── Polling interface ─────────────────────────────────────────────────
+
+    /// Blocking read — waits until a message arrives or the call is released.
+    ///
+    /// `timeout: None` blocks indefinitely until a message or a close event.
+    /// Returns `Err(OperationNotPermitted)` if any listener is registered
+    /// (CERT CAL-016050).
+    fn read(&mut self, timeout: Option<Duration>) -> CalResult<Option<Arc<M>>>;
+
+    /// Non-blocking read — returns a buffered message if one is available.
+    fn read_no_wait(&mut self) -> CalResult<Option<Arc<M>>>;
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────
+
+    /// Shuts down this reader and releases all associated resources.
+    fn close(self: Box<Self>) -> CalResult<()>;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// QoS settings
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Reliability policy for a Client Topic (CERT CAL-005434, CAL-016076).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Reliability {
+    /// Best-effort delivery — messages may be dropped (default).
+    #[default]
+    BestEffort,
+    /// Reliable delivery — unacknowledged messages are retransmitted in order.
+    Reliable,
+}
+
+/// Minimum inter-arrival gap for accepted messages (CERT CAL-005431).
+///
+/// The reader silently drops any message received within `min_separation` of
+/// the previously accepted message.
+#[derive(Debug, Clone)]
+pub struct TimeBasedFilter {
+    /// Minimum time that must elapse between two consecutively accepted messages.
+    pub min_separation: Duration,
+}
+
+/// Maximum lifetime for a buffered message (CERT CAL-005437).
+///
+/// Messages older than `max_age` are removed from the receive buffer.
+#[derive(Debug, Clone)]
+pub struct Expiration {
+    /// Age after which a buffered message is discarded.
+    pub max_age: Duration,
+}
+
+/// Bounded message buffer (CERT CAL-005444, CAL-005445, CAL-015746, CAL-016079).
+///
+/// Used for both the writer-side send buffer (`TopicQos::writer_buffer`) and
+/// the reader-side receive buffer (`TopicQos::reader_buffer`). When the count
+/// of buffered messages exceeds `max_messages`, the oldest is dropped.
+#[derive(Debug, Clone)]
+pub struct MessageBuffer {
+    /// Maximum number of messages held in the buffer before the oldest is dropped.
+    pub max_messages: usize,
+}
+
+/// Aggregate Quality of Service settings for a Client Topic (CERT CAL-005210).
+///
+/// Pass to [`AbstractCalExt::create_writer`] or [`AbstractCalExt::create_reader`]
+/// at creation time.  The default value selects best-effort reliability with no
+/// filtering, no expiration, and unbounded buffers.
+#[derive(Debug, Clone, Default)]
+pub struct TopicQos {
+    /// Delivery reliability policy (default: `BestEffort`).
+    pub reliability: Reliability,
+    /// Time-based filter applied on the reader side; `None` disables filtering.
+    pub time_based_filter: Option<TimeBasedFilter>,
+    /// Message lifetime on the reader's receive buffer; `None` disables expiry.
+    pub expiration: Option<Expiration>,
+    /// Writer-side send buffer limit; `None` means unbounded.
+    pub writer_buffer: Option<MessageBuffer>,
+    /// Reader-side receive buffer limit; `None` means unbounded.
+    pub reader_buffer: Option<MessageBuffer>,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AbstractCal
+// ════════════════════════════════════════════════════════════════════════════
+
+/// CAL application-layer interface. Supertrait of [`AbstractServiceBus`].
+///
+/// Every `AbstractCal` IS-A `AbstractServiceBus`: it exposes the full transport
+/// identity and status interface, plus the CAL-layer concerns that applications
+/// actually use (message header defaults, typed writer/reader factories).
+///
+/// # Object safety
+/// `AbstractCal` is object-safe; store instances as `Arc<Mutex<dyn AbstractCal>>`.
+/// Generic factory methods live in the separate non-object-safe [`AbstractCalExt<M>`]
+/// trait.
+///
+/// # CERT coverage
+/// CAL-005201, CAL-005202, CAL-005203
+pub trait AbstractCal: AbstractServiceBus {
+    /// Returns the defaults used to pre-populate `MessageHeader` and
+    /// `SecurityInformation` fields when creating a new message.
+    ///
+    /// Sourced from the `[system]` and `[service]` sections of the CAL
+    /// configuration file.
+    fn message_header_defaults(&self) -> MessageHeaderDefaults;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AbstractCalExt
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Extension trait adding typed factory methods to [`AbstractCal`].
+///
+/// Separated so that `AbstractCal` remains object-safe —
+/// `dyn AbstractCal` can still be stored in `Arc<Mutex<...>>`.
+/// Factory methods are called through a concrete or generic reference.
+///
+/// # CERT coverage
+/// CAL-005364 (`create_writer`), CAL-005374 (`create_reader`)
+pub trait AbstractCalExt<M: CalMessage>: AbstractCal {
+    /// Creates an [`AbstractWriter`] bound to `topic` with the given QoS
+    /// settings (CERT CAL-005364, CAL-005210).
+    ///
+    /// Returns `Err(TopicUnavailable)` if `topic` is not a valid Client Topic
+    /// for this service (CERT CAL-005368, CAL-005369).
+    fn create_writer(
+        &mut self,
+        topic: &str,
+        qos: TopicQos,
+    ) -> CalResult<Box<dyn AbstractWriter<M>>>;
+
+    /// Creates an [`AbstractReader`] bound to `topic` with the given QoS
+    /// settings (CERT CAL-005374, CAL-005210).
+    ///
+    /// The topic connection and message buffering are established before this
+    /// returns (CERT CAL-005394, CAL-016044).
+    ///
+    /// Returns `Err(TopicUnavailable)` if `topic` is not a valid Client Topic
+    /// (CERT CAL-005378).
+    fn create_reader(
+        &mut self,
+        topic: &str,
+        qos: TopicQos,
+    ) -> CalResult<Box<dyn AbstractReader<M>>>;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AbstractCalCreateMessage
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Extension trait that adds typed message creation to any [`AbstractCal`].
+///
+/// Implemented as a blanket impl over all `AbstractCal` types so that
+/// transport implementations do not need to duplicate this logic.
+///
+/// Use this instead of constructing message types directly — generated structs
+/// have no public constructors (CERT CAL-016035).
+pub trait AbstractCalCreateMessage {
+    /// Creates a default-initialised instance of message type `M`.
+    ///
+    /// Equivalent to the C++ `<Type>::create(asb)` static factory.
+    fn create_message<M: CalMessage>(&self) -> CalResult<M>;
+}
+
+impl<T: AbstractCal> AbstractCalCreateMessage for T {
+    fn create_message<M: CalMessage>(&self) -> CalResult<M> {
+        let mut msg = M::cal_create();
+        if let Some(mt) = msg.as_message_type_mut() {
+            let defaults = self.message_header_defaults();
+            let hdr = mt.message_header_mut();
+            *hdr.system_id_mut().uuid_mut() = defaults.system_id;
+            *hdr.schema_version_mut() = defaults.schema_version;
+            *hdr.mode_mut() = defaults.mode;
+            *hdr.timestamp_mut() = Utc::now().into();
+            if let (Some(sid), Some(sfield)) = (defaults.service_id, hdr.service_id_mut()) {
+                *sfield.uuid_mut() = sid;
+            }
+            if let (Some(mid), Some(mfield)) = (defaults.mission_id, hdr.mission_id_mut()) {
+                *mfield.uuid_mut() = mid;
+            }
+            let sec = mt.security_information_mut();
+            *sec.classification_mut() = defaults.classification;
+            let op = sec.owner_producer_mut();
+            op.clear();
+            op.extend(defaults.owner_producer);
+        }
+        Ok(msg)
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Factory
+// ════════════════════════════════════════════════════════════════════════════
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct AsbKey {
+    pub(crate) service_identifier: String,
+    pub(crate) asb_identifier: String,
+}
+
+type CalInstance = Arc<Mutex<dyn AbstractCal>>;
+type CalFactoryMap = HashMap<AsbKey, CalInstance>;
+
+lazy_static! {
+    static ref CAL_FACTORY: tokio::sync::Mutex<CalFactoryMap> =
+        tokio::sync::Mutex::new(CalFactoryMap::new());
+}
+
+/// Returns the [`AbstractCal`] instance for `(service_identifier, asb_identifier)`,
+/// creating it if it does not yet exist.
+///
+/// Satisfies CERT CAL-005201 (mechanism to obtain a fully initialised CAL
+/// instance) and CERT CAL-005202 (one instance per unique key pair).
+///
+/// Returns `Err(InitializationFailure)` when no matching (or default)
+/// transport is configured, or when the underlying constructor fails.
+pub async fn get_cal(
+    service_identifier: impl Into<String>,
+    asb_identifier: impl Into<String>,
+    config: Arc<CalConfig>,
+    logger: slog::Logger,
+) -> CalResult<CalInstance> {
+    let key = AsbKey {
+        service_identifier: service_identifier.into(),
+        asb_identifier: asb_identifier.into(),
+    };
+
+    // Hold the factory lock for the entire construction to prevent concurrent
+    // callers from constructing duplicate instances that bind the same socket.
+    let mut map = CAL_FACTORY.lock().await;
+
+    if let Some(existing) = map.get(&key) {
+        return Ok(Arc::clone(existing));
+    }
+
+    let transport = config
+        .get_transport(&key.asb_identifier)
+        .or_else(|| {
+            config
+                .system
+                .default_transport
+                .as_ref()
+                .and_then(|def| config.get_transport(def))
+        })
+        .ok_or_else(|| {
+            CalError::new(
+                CalErrorKind::InitializationFailure,
+                format!(
+                    "No transport configured for '{}' and no default_transport available.",
+                    key.asb_identifier
+                ),
+            )
+        })?;
+
+    let instance: CalInstance = match transport.type_.as_str() {
+        #[cfg(feature = "zmq")]
+        ZMQ_ASB_ID => Arc::new(Mutex::new(
+            ZmqAsb::new(
+                key.service_identifier.clone(),
+                key.asb_identifier.clone(),
+                logger,
+                Arc::clone(&config),
+                transport,
+            )
+            .await?,
+        )),
+        other => {
+            return Err(CalError::new(
+                CalErrorKind::InitializationFailure,
+                format!("Unknown ASB transport type: '{other}'."),
+            ));
+        }
+    };
+
+    map.insert(key, Arc::clone(&instance));
+    Ok(instance)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Unit tests
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::asb::NEXT_TEST_PORT;
+    use crate::asb::zmq::test_config_on_ports;
+    use rcal_macros::init_test_logger;
+    use std::sync::atomic::Ordering;
+
+    #[cfg(feature = "zmq")]
+    #[init_test_logger]
+    #[tokio::test]
+    async fn test_cal_factory_same_key_returns_same_instance() {
+        let p1 = NEXT_TEST_PORT.fetch_add(1, Ordering::SeqCst);
+        let p2 = NEXT_TEST_PORT.fetch_add(1, Ordering::SeqCst);
+        let config = test_config_on_ports(&[p1, p2]);
+
+        let a = get_cal("test_svc", "TestZmq", Arc::clone(&config), logger.clone())
+            .await
+            .expect("first get_cal must succeed");
+        let b = get_cal("test_svc", "TestZmq", Arc::clone(&config), logger.clone())
+            .await
+            .expect("second get_cal must succeed");
+        let c = get_cal(
+            "test_svc_2",
+            "TestZmq2",
+            Arc::clone(&config),
+            logger.clone(),
+        )
+        .await
+        .expect("different service must succeed");
+
+        assert!(Arc::ptr_eq(&a, &b), "same key should return the same Arc");
+        assert!(
+            !Arc::ptr_eq(&a, &c),
+            "different service key must be a distinct instance"
+        );
+    }
+}

--- a/rcal/src/lib.rs
+++ b/rcal/src/lib.rs
@@ -5,6 +5,7 @@
 //! - OMSC-SPC-008 Rev K — C++ CAL Interface Generation Specification
 
 pub mod asb;
+pub mod cal;
 pub mod calconfig;
 pub mod logging;
 pub mod qname;

--- a/rcal/src/service/mod.rs
+++ b/rcal/src/service/mod.rs
@@ -14,9 +14,9 @@ use std::time::Duration;
 
 use slog::{error, info, trace, warn};
 
-use crate::asb::{
-    AbstractServiceBus, AbstractServiceBusCreateMessage, AbstractServiceBusExt, AbstractWriter,
-    MessageListener, TopicQos,
+use crate::cal::{
+    AbstractCal, AbstractCalCreateMessage, AbstractCalExt, AbstractWriter, MessageListener,
+    TopicQos,
 };
 use crate::calconfig::CalConfig;
 use crate::uci::{CalMessage, CalResult};
@@ -89,10 +89,10 @@ where
 // AbstractServiceImpl
 // ════════════════════════════════════════════════════════════════════════════
 
-/// Concrete AbstractService implementation, generic over the ASB type `A`.
+/// Concrete AbstractService implementation, generic over the CAL type `A`.
 ///
-/// `A` is held directly (not via `dyn AbstractServiceBus`) so that the
-/// generic `AbstractServiceBusExt<M>` methods remain callable at the method level.
+/// `A` is held directly (not via `dyn AbstractCal`) so that the
+/// generic `AbstractCalExt<M>` methods remain callable at the method level.
 #[rcal_macros::monitor]
 pub struct AbstractServiceImpl<A> {
     service_id: String,
@@ -107,7 +107,7 @@ pub struct AbstractServiceImpl<A> {
     _readers: std::sync::Mutex<Vec<Box<dyn Any + Send>>>,
 }
 
-impl<A: AbstractServiceBus> AbstractServiceImpl<A> {
+impl<A: AbstractCal> AbstractServiceImpl<A> {
     /// Constructs a new `AbstractServiceImpl`.
     ///
     /// `subsystem_ids` may be empty; they are stored and returned via
@@ -139,7 +139,7 @@ impl<A: AbstractServiceBus> AbstractServiceImpl<A> {
         }
     }
 
-    /// Creates a typed message, pre-populated with ASB header defaults.
+    /// Creates a typed message, pre-populated with CAL header defaults.
     pub fn create_message<M: CalMessage>(&self) -> CalResult<M> {
         trace!(self.logger, "AbstractServiceImpl::create_message";
             "service_id" => &self.service_id,
@@ -155,7 +155,7 @@ impl<A: AbstractServiceBus> AbstractServiceImpl<A> {
     ) -> CalResult<Box<dyn AbstractWriter<M>>>
     where
         M: CalMessage,
-        A: AbstractServiceBusExt<M>,
+        A: AbstractCalExt<M>,
     {
         trace!(self.logger, "AbstractServiceImpl::create_writer";
             "service_id" => &self.service_id,
@@ -172,7 +172,7 @@ impl<A: AbstractServiceBus> AbstractServiceImpl<A> {
     pub fn create_reader<M, F>(&mut self, topic: &str, qos: TopicQos, callback: F) -> CalResult<()>
     where
         M: CalMessage + 'static,
-        A: AbstractServiceBusExt<M>,
+        A: AbstractCalExt<M>,
         F: Fn(Arc<M>, &str) + Send + Sync + 'static,
     {
         trace!(self.logger, "AbstractServiceImpl::create_reader";
@@ -237,7 +237,7 @@ impl<A: AbstractServiceBus> AbstractServiceImpl<A> {
     }
 }
 
-impl<A: AbstractServiceBus> AbstractService for AbstractServiceImpl<A> {
+impl<A: AbstractCal> AbstractService for AbstractServiceImpl<A> {
     fn system_id(&self) -> &str {
         &self.system_id
     }
@@ -371,7 +371,8 @@ fn parse_duration(s: &str) -> Result<Duration, &'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::asb::{AsbStatus, AsbStatusListener, MessageHeaderDefaults};
+    use crate::asb::{AbstractServiceBus, AsbStatus, AsbStatusListener};
+    use crate::cal::MessageHeaderDefaults;
     use crate::calconfig::CalConfig;
     use crate::uci::base::UUID;
 
@@ -435,6 +436,9 @@ mod tests {
         fn close(&mut self) -> crate::uci::CalResult<()> {
             Ok(())
         }
+    }
+
+    impl AbstractCal for NullAsb {
         fn message_header_defaults(&self) -> MessageHeaderDefaults {
             unimplemented!()
         }

--- a/rcal/src/uci/base.rs
+++ b/rcal/src/uci/base.rs
@@ -27,11 +27,12 @@ use std::fmt;
 use uuid::{Uuid, Variant as UuidVariant, Version as UuidVersion};
 
 /// Re-exports for uci::asb
-///
-pub use crate::asb::{
-    AbstractReader, AbstractServiceBus, AbstractServiceBusCreateMessage, AbstractServiceBusExt,
-    AbstractWriter, AsbConnectionState, AsbStatus, AsbStatusListener, Expiration, MessageBuffer,
-    MessageListener, Reliability, TimeBasedFilter, TopicQos,
+pub use crate::asb::{AbstractServiceBus, AsbConnectionState, AsbStatus, AsbStatusListener};
+/// Re-exports for uci::cal
+pub use crate::cal::{
+    AbstractCal, AbstractCalCreateMessage, AbstractCalExt, AbstractReader, AbstractWriter,
+    Expiration, MessageBuffer, MessageHeaderDefaults, MessageListener, Reliability,
+    TimeBasedFilter, TopicQos,
 };
 pub use crate::calconfig::SerializationFormat;
 

--- a/rcal/src/uci/base.rs
+++ b/rcal/src/uci/base.rs
@@ -10,7 +10,7 @@
 //!
 //! ## Design notes
 //! * [`AbstractServiceBus`] is object-safe; generic factory methods live in
-//!   the non-object-safe extension trait [`AbstractServiceBusExt`].
+//!   the non-object-safe extension trait [`AbstractCalExt`].
 //! * `Send + Sync` is required on all shared types (§5.1.1, CAL-016015).
 //! * `Box<Self>` receivers are used for consuming trait-object methods, which
 //!   is the Rust equivalent of C++ destructors and `shutdown()` calls.

--- a/rcal/tests/zmq_asb_system.rs
+++ b/rcal/tests/zmq_asb_system.rs
@@ -1,4 +1,4 @@
-//! System-level integration tests for [`ZmqAsb`] / [`AbstractServiceBusExt`].
+//! System-level integration tests for [`ZmqAsb`] / [`AbstractCalExt`].
 //!
 //! Each test creates real `ZmqAsb` instances and exercises the full
 //! writer → RADIO → DISH → reader path with XML serialization.
@@ -9,7 +9,7 @@ use std::time::Duration;
 use rcal::QName;
 use rcal::asb::zmq::ZmqAsb;
 use rcal::uci::CalMessage;
-use rcal::uci::base::{AbstractServiceBus, AbstractServiceBusExt, MessageListener, TopicQos};
+use rcal::uci::base::{AbstractCalExt, AbstractServiceBus, MessageListener, TopicQos};
 
 // ── port allocator (multiprocess test only) ───────────────────────────────────
 
@@ -106,44 +106,29 @@ impl MessageListener<IntMsg> for CollectListener {
 async fn test_three_clients_shared_bus() {
     let mut bus = make_bus("Sys", "shared-bus", logger).await;
 
-    let mut a_writer = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_writer(
-        &mut bus,
-        "data",
-        TopicQos::default(),
-    )
-    .unwrap();
+    let mut a_writer =
+        <ZmqAsb as AbstractCalExt<IntMsg>>::create_writer(&mut bus, "data", TopicQos::default())
+            .unwrap();
 
-    let mut b_reader = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_reader(
-        &mut bus,
-        "data",
-        TopicQos::default(),
-    )
-    .unwrap();
-    let mut b_writer = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_writer(
-        &mut bus,
-        "status",
-        TopicQos::default(),
-    )
-    .unwrap();
+    let mut b_reader =
+        <ZmqAsb as AbstractCalExt<IntMsg>>::create_reader(&mut bus, "data", TopicQos::default())
+            .unwrap();
+    let mut b_writer =
+        <ZmqAsb as AbstractCalExt<IntMsg>>::create_writer(&mut bus, "status", TopicQos::default())
+            .unwrap();
 
     let c_data_log: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
-    let mut c_data_reader = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_reader(
-        &mut bus,
-        "data",
-        TopicQos::default(),
-    )
-    .unwrap();
+    let mut c_data_reader =
+        <ZmqAsb as AbstractCalExt<IntMsg>>::create_reader(&mut bus, "data", TopicQos::default())
+            .unwrap();
     c_data_reader
         .add_listener(Arc::new(CollectListener {
             received: Arc::clone(&c_data_log),
         }))
         .unwrap();
-    let mut c_status_reader = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_reader(
-        &mut bus,
-        "status",
-        TopicQos::default(),
-    )
-    .unwrap();
+    let mut c_status_reader =
+        <ZmqAsb as AbstractCalExt<IntMsg>>::create_reader(&mut bus, "status", TopicQos::default())
+            .unwrap();
 
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -201,20 +186,14 @@ async fn test_three_clients_separate_radios() {
     bus_c.add_receive_peer("inproc://sep-client-a");
     bus_c.add_receive_peer("inproc://sep-client-b");
 
-    let mut a_writer = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_writer(
-        &mut bus_a,
-        "data",
-        TopicQos::default(),
-    )
-    .unwrap();
+    let mut a_writer =
+        <ZmqAsb as AbstractCalExt<IntMsg>>::create_writer(&mut bus_a, "data", TopicQos::default())
+            .unwrap();
 
-    let mut b_reader = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_reader(
-        &mut bus_b,
-        "data",
-        TopicQos::default(),
-    )
-    .unwrap();
-    let mut b_writer = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_writer(
+    let mut b_reader =
+        <ZmqAsb as AbstractCalExt<IntMsg>>::create_reader(&mut bus_b, "data", TopicQos::default())
+            .unwrap();
+    let mut b_writer = <ZmqAsb as AbstractCalExt<IntMsg>>::create_writer(
         &mut bus_b,
         "status",
         TopicQos::default(),
@@ -222,18 +201,15 @@ async fn test_three_clients_separate_radios() {
     .unwrap();
 
     let c_data_log: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
-    let mut c_data_reader = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_reader(
-        &mut bus_c,
-        "data",
-        TopicQos::default(),
-    )
-    .unwrap();
+    let mut c_data_reader =
+        <ZmqAsb as AbstractCalExt<IntMsg>>::create_reader(&mut bus_c, "data", TopicQos::default())
+            .unwrap();
     c_data_reader
         .add_listener(Arc::new(CollectListener {
             received: Arc::clone(&c_data_log),
         }))
         .unwrap();
-    let mut c_status_reader = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_reader(
+    let mut c_status_reader = <ZmqAsb as AbstractCalExt<IntMsg>>::create_reader(
         &mut bus_c,
         "status",
         TopicQos::default(),
@@ -296,12 +272,9 @@ async fn test_multiprocess_receive_peer() {
     let mut bus = make_tcp_bus("Receiver", port_r, logger).await;
     bus.add_receive_peer(format!("tcp://127.0.0.1:{port_s}"));
 
-    let mut reader = <ZmqAsb as AbstractServiceBusExt<IntMsg>>::create_reader(
-        &mut bus,
-        "data",
-        TopicQos::default(),
-    )
-    .unwrap();
+    let mut reader =
+        <ZmqAsb as AbstractCalExt<IntMsg>>::create_reader(&mut bus, "data", TopicQos::default())
+            .unwrap();
 
     // read() uses cvar.wait_timeout which blocks the tokio executor thread, preventing
     // the reader task from running. Sleep long enough for the sender process to start,

--- a/rcal/tests/zmq_qos.rs
+++ b/rcal/tests/zmq_qos.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use rcal::QName;
 use rcal::asb::zmq::ZmqAsb;
 use rcal::uci::CalMessage;
-use rcal::uci::base::{AbstractServiceBus, AbstractServiceBusExt, TopicQos};
+use rcal::uci::base::{AbstractCalExt, AbstractServiceBus, TopicQos};
 
 // ── shared port allocator ─────────────────────────────────────────────────────
 
@@ -76,14 +76,10 @@ async fn test_qos_time_based_filter() {
         ..TopicQos::default()
     };
     let mut reader =
-        <ZmqAsb as AbstractServiceBusExt<QosMsg>>::create_reader(&mut bus, "t", reader_qos)
+        <ZmqAsb as AbstractCalExt<QosMsg>>::create_reader(&mut bus, "t", reader_qos).unwrap();
+    let mut writer =
+        <ZmqAsb as AbstractCalExt<QosMsg>>::create_writer(&mut bus, "t", TopicQos::default())
             .unwrap();
-    let mut writer = <ZmqAsb as AbstractServiceBusExt<QosMsg>>::create_writer(
-        &mut bus,
-        "t",
-        TopicQos::default(),
-    )
-    .unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Burst: only the first message should pass the filter
@@ -142,14 +138,10 @@ async fn test_qos_expiration() {
         ..TopicQos::default()
     };
     let mut reader =
-        <ZmqAsb as AbstractServiceBusExt<QosMsg>>::create_reader(&mut bus, "t", reader_qos)
+        <ZmqAsb as AbstractCalExt<QosMsg>>::create_reader(&mut bus, "t", reader_qos).unwrap();
+    let mut writer =
+        <ZmqAsb as AbstractCalExt<QosMsg>>::create_writer(&mut bus, "t", TopicQos::default())
             .unwrap();
-    let mut writer = <ZmqAsb as AbstractServiceBusExt<QosMsg>>::create_writer(
-        &mut bus,
-        "t",
-        TopicQos::default(),
-    )
-    .unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Write 3 messages, wait for them to expire
@@ -206,14 +198,10 @@ async fn test_qos_reader_buffer() {
         ..TopicQos::default()
     };
     let mut reader =
-        <ZmqAsb as AbstractServiceBusExt<QosMsg>>::create_reader(&mut bus, "t", reader_qos)
+        <ZmqAsb as AbstractCalExt<QosMsg>>::create_reader(&mut bus, "t", reader_qos).unwrap();
+    let mut writer =
+        <ZmqAsb as AbstractCalExt<QosMsg>>::create_writer(&mut bus, "t", TopicQos::default())
             .unwrap();
-    let mut writer = <ZmqAsb as AbstractServiceBusExt<QosMsg>>::create_writer(
-        &mut bus,
-        "t",
-        TopicQos::default(),
-    )
-    .unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     for i in 0..5u32 {

--- a/rcal/xsd-subset/src/main.rs
+++ b/rcal/xsd-subset/src/main.rs
@@ -1,3 +1,29 @@
+//! Developer tool to create a subset of a schema file.
+//!
+//! This tool extracts the specified messages from a schema file and writes them to another schema file.
+//! The specified message elements and all required types are included in the subset. After creating a subset.xsd
+//! you can use `export RCAL_XSD_PATH=/path/to/subset.xsd` to only generate the subset elements. Alternatively you can
+//! add the following to `.cargo/config.toml`
+//! ```toml
+//! [env]
+//! RCAL_XSD_PATH="/path/to/subset.xsd"
+//! ````
+//! # Note
+//! This is generally used to create a schema for a particular system containing all possible elements.
+//! If you are building a service and only want to build struct for the elements used in that service
+//! it is preferable to add this to `.cargo/config.toml` instead.
+//! ```toml
+//! [env]
+//! RCAL_CALCONFIG_PATH="/path/to/services/CALConfig.toml"
+//! ```
+//!
+//! This will extract, at compile time, the needed messages from the calconfig file used by the service.
+//!
+//! # Usage
+//!   cargo run --bin xsd-subset -- --schema </path/to/full.xsd> --output </path/to/subset.xsd> \[message...]
+//!
+//! where `message` is a the name of an OMS Message you want in the subset.
+
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;


### PR DESCRIPTION
Closes #72

## Summary

- Strips `asb/mod.rs` to a pure transport layer (`AbstractServiceBus`): identity UUIDs, connection state/status, lifecycle — no message-type knowledge
- Adds `cal/mod.rs` with the CAL application layer: `AbstractCal` (supertrait of `AbstractServiceBus`), `AbstractCalExt<M>`, `AbstractCalCreateMessage`, `AbstractWriter<M>`, `AbstractReader<M>`, QoS types, `MessageHeaderDefaults`, and `get_cal()` factory (replaces `get_asb()`)
- `ZmqAsb` implements all three traits via separate impl blocks
- Updates archimate design document to reflect the two-layer separation
- Updates all consumers: `service/mod.rs`, `uci/base.rs`, examples, integration tests, and the `zmq_peer_sender` binary

## CERT coverage

CAL-005201, CAL-005202, CAL-005203, CAL-005364, CAL-005374, CAL-016366

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --no-deps` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo test --workspace --all-targets` — 67 tests pass (58 unit + 9 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)