### PR TITLE
feat(xs): add AnyUri, NormalizedString, Token type aliases (closes #77)

### DIFF
--- a/rcal/build.rs
+++ b/rcal/build.rs
@@ -1967,6 +1967,9 @@ fn xsd_to_rust(ns: Option<&str>, local: &str) -> String {
             "dateTime" => return "crate::xs::DateTime".to_string(),
             "time" => return "crate::xs::Time".to_string(),
             "string" => return "crate::xs::XsString".to_string(),
+            "anyURI" => return "crate::xs::AnyUri".to_string(),
+            "normalizedString" => return "crate::xs::NormalizedString".to_string(),
+            "token" => return "crate::xs::Token".to_string(),
             "hexBinary" => return "crate::xs::HexBinary".to_string(),
             _ => {}
         }

--- a/rcal/src/xs.rs
+++ b/rcal/src/xs.rs
@@ -23,6 +23,9 @@
 //! | `xs:dateTime`      | `DateTime` (chrono UTC) | **CERT CAL-016028**        |
 //! | `xs:time`          | `i64` (ns since 00:00Z) | **CERT CAL-016029**        |
 //! | `xs:string`        | `String`                | OMSC-SPC-008 Table 9.1-2   |
+//! | `xs:anyURI`        | `String`                | **CERT CXX-004940**        |
+//! | `xs:normalizedString` | `String`             | **CERT CXX-004940**        |
+//! | `xs:token`         | `String`                | **CERT CXX-004940**        |
 //! | `xs:hexBinary`     | `Vec<u8>`               | OMSC-SPC-008 Table 9.1-3   |
 //! | `xs:base64Binary`  | `Vec<u8>`               | OMSC-SPC-008 Table 9.1-3   |
 //!
@@ -171,6 +174,15 @@ pub type XsString = String;
 /// `xs:string` accessor — same as [`XsString`]; provided for symmetry with
 /// the C++ `StringAccessor` class.
 pub type StringAccessor = String;
+
+/// `xs:anyURI` — string-valued URI (CERT CXX-004940).
+pub type AnyUri = String;
+
+/// `xs:normalizedString` — whitespace-normalized string (CERT CXX-004940).
+pub type NormalizedString = String;
+
+/// `xs:token` — whitespace-collapsed string (CERT CXX-004940).
+pub type Token = String;
 
 // ── Binary types (OMSC-SPC-008 Table 9.1-3) ─────────────────────────────────
 


### PR DESCRIPTION
Closes #77

## Summary
- Adds `xs::AnyUri`, `xs::NormalizedString`, and `xs::Token` type aliases to `xs.rs` (all `= String`)
- Adds `anyURI`, `normalizedString`, and `token` entries to the `xsd_to_rust` table in `build.rs` so generated accessor code uses the named aliases rather than bare `String`
- Updates the module-level doc table to include the three new types

## CERT coverage
- CERT CXX-004940 (string primitive type aliases)

## Test plan
- [ ] `cargo check --workspace --all-targets` passes
- [ ] `cargo clippy --no-deps` passes
- [ ] `cargo fmt --all` no changes
- [ ] `cargo test --workspace --all-targets` all 58+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)