### PR TITLE
feat(ci): add milestone-triggered release automation

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,33 @@
+name: Release PR
+
+on:
+  milestone:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-pr:
+    name: Create release PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rcal
+
+      - name: release-plz update
+        uses: release-plz/action@v0.5
+        with:
+          manifest_path: rcal/Cargo.toml
+          command: release-plz update
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Tag and publish release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rcal
+
+      - name: release-plz release
+        uses: release-plz/action@v0.5
+        with:
+          manifest_path: rcal/Cargo.toml
+          command: release-plz release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,53 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}\
+
+### {{ group | striptags | trim | upper_first }}
+
+{% for commit in commits %}\
+- {% if commit.scope %}**{{ commit.scope }}**: {% endif %}\
+{{ commit.message | upper_first }}\
+ ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/tclarke/rcal/commit/{{ commit.id }}))\
+{% if commit.breaking %} **BREAKING CHANGE**{% endif %}
+{% endfor %}\
+{% endfor %}\
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+# Anchor changelog ranges on rcal-v* tags only; rcal_macros-v* tags cover the
+# same commits and would create duplicate sections.
+tag_pattern = "rcal-v[0-9]*"
+commit_parsers = [
+  { message = "^feat",               group = "Features" },
+  { message = "^fix",                group = "Bug Fixes" },
+  { message = "^doc",                group = "Documentation" },
+  { message = "^docs",               group = "Documentation" },
+  { message = "^perf",               group = "Performance" },
+  { message = "^refactor",           group = "Refactoring" },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore",              skip = true },
+  { message = "^ci",                 skip = true },
+  { message = "^build",              skip = true },
+  { message = "^style",              skip = true },
+  { message = "^test",               skip = true },
+]
+filter_commits = true
+protect_breaking_commits = false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,19 @@
+[workspace]
+manifest_path = "rcal/Cargo.toml"
+changelog_config = "cliff.toml"
+git_release_enable = true
+git_tag_name = "{{ package }}-v{{ version }}"
+
+[[package]]
+name = "rcal_macros"
+changelog_update = false
+
+[[package]]
+name = "simple_two_service"
+release = false
+changelog_update = false
+
+[[package]]
+name = "rcal-xsd-subset"
+release = false
+changelog_update = false


### PR DESCRIPTION
## Summary

- Add `release-plz.toml` — workspace config, excludes example and dev-tool crates from release
- Add `cliff.toml` — conventional commit parser, Keep a Changelog format
- Add `.github/workflows/release-pr.yml` — triggered on milestone close, creates release PR with bumped version + CHANGELOG
- Add `.github/workflows/release.yml` — triggered on push to main, creates GPG-signed tags and GitHub Releases when release PR is merged

## Test plan

- [x] Set three GitHub Secrets: `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `RELEASE_PLZ_TOKEN` (PAT with `repo` + `workflow` scope)
- [ ] Close a test milestone → verify release PR is created with correct version bump and CHANGELOG section
- [ ] Merge the release PR → verify GPG-signed tags `rcal-vX.Y.Z` and `rcal_macros-vX.Y.Z` are created and GitHub Releases appear

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)