### PR TITLE
feat(uci/base): add Externalizer/ExternalizerLoader abstraction (closes #54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Always perform "Coding review and checks" when finished implementing.
 Always update the issue start date and set status to "In Progress" when starting a new task
 Always set the issue status to "In Review" when a PR has been created.
 Always update the end date after the PR has been merged.
+Always mention the issue number in a PR so that they are linked in github.
 
 # Coding review and checks
  - After implementing a new feature and before creating a PR, run the following tools.

--- a/design/oms_rust_cal_core.archimate
+++ b/design/oms_rust_cal_core.archimate
@@ -99,18 +99,32 @@
         <documentation>Reader-side minimum inter-arrival filter. Messages received within min_separation of the last accepted message are dropped (CAL-005431). Field: min_separation: Option(Duration). CERT: CAL-005431.</documentation>
       </element>
     </folder>
+    <folder name="Externalizer" id="f-ext">
+      <element xsi:type="archimate:ApplicationInterface" name="Externalizer(M)" id="e-externalizer">
+        <documentation>Abstract serialization/deserialization interface. Generic over M: CalMessage. Object-safe per concrete M — dyn Externalizer(M) is valid. I/O methods: read_from_reader(&amp;mut dyn io::Read), read_from_str(&amp;str), read_from_bytes(&amp;[u8]), write_to_writer(&amp;M, &amp;mut dyn io::Write), write_to_string(&amp;M), write_to_bytes(&amp;M). Identity methods: get_cal_api_version, get_encoding, get_schema_version, get_vendor_version, get_vendor. Capability methods: message_read_only, message_write_only, supports_object_read, supports_object_write. Rust equivalent of uci::base::Externalizer in OMSC-SPC-008 §9.13. CERTs: CXX-012071, CXX-012099, CXX-012115, CXX-012131, CXX-012146, CXX-012161, CXX-012176, CXX-012238, CXX-012252, CXX-012266, CXX-012280, CXX-012294, CXX-012688, CXX-012689, CXX-012690, CXX-012691.</documentation>
+      </element>
+      <element xsi:type="archimate:ApplicationInterface" name="ExternalizerLoader(M)" id="e-extloader">
+        <documentation>Factory trait for obtaining Externalizer instances by encoding string. Generic over M: CalMessage. Method: get_externalizer(encoding: &amp;str, schema_version: &amp;str, vendor_version: &amp;str) returning CalResult(Box(dyn Externalizer(M))). destroy_externalizer is a no-op in Rust (Box drop). Rust equivalent of uci::base::ExternalizerLoader in OMSC-SPC-008 §9.14. CERTs: CXX-012338, CXX-012367, CXX-012381.</documentation>
+      </element>
+      <element xsi:type="archimate:ApplicationComponent" name="XmlExternalizer" id="e-xmlext">
+        <documentation>Concrete Externalizer using quick_xml for serialization. Blanket impl over M: CalMessage + Serialize + DeserializeOwned. Stores format: SerializationFormat and root: String (XML root element name, typically the topic name). Implements all Externalizer(M) methods. get_encoding() returns "xml". Moved from private functions in zmq.rs. Lives in rcal::externalizer module.</documentation>
+      </element>
+      <element xsi:type="archimate:ApplicationComponent" name="XmlExternalizerLoader" id="e-xmlextloader">
+        <documentation>Concrete ExternalizerLoader. get_externalizer("xml", ...) returns XmlExternalizer; returns SerializationError for unrecognised encodings. Global function get_externalizer_loader() returns Box(dyn ExternalizerLoader(M)) wrapping XmlExternalizerLoader (CXX-012434). destroy_externalizer_loader() is a no-op (CXX-012446). Lives in rcal::externalizer module.</documentation>
+      </element>
+    </folder>
     <folder name="ZMQ Implementation" id="f-zmq">
       <element xsi:type="archimate:ApplicationComponent" name="ZmqAsb" id="e-zmqasb">
-        <documentation>omq-tokio RADIO/DISH-backed concrete implementation of AbstractServiceBus and AbstractServiceBusExt. Owns a RADIO socket via a background tokio task; ZmqWriters enqueue through a channel. Each ZmqReader owns an independent DISH socket in its own background task. Transport URI from CalConfig [[transport]]. For multi-process topologies, peer RADIO URIs are registered via add_receive_peer(); readers connect DISH to all peers. RADIO binds for TCP/inproc; RADIO connects for UDP (DISH binds for UDP). Serialization controlled by SerializationFormat in transport config.</documentation>
+        <documentation>omq-tokio RADIO/DISH-backed concrete implementation of AbstractServiceBus and AbstractServiceBusExt. Owns a RADIO socket via a background tokio task; ZmqWriters enqueue through a channel. Each ZmqReader owns an independent DISH socket in its own background task. Transport URI from CalConfig [[transport]]. For multi-process topologies, peer RADIO URIs are registered via add_receive_peer(); readers connect DISH to all peers. RADIO binds for TCP/inproc; RADIO connects for UDP (DISH binds for UDP). Creates XmlExternalizer (from transport SerializationFormat config) and passes it to ZmqWriter/ZmqReader.</documentation>
       </element>
       <element xsi:type="archimate:ApplicationComponent" name="ZmqWriter(M)" id="e-zmqwriter">
-        <documentation>Concrete AbstractWriter for the ZMQ transport. Serializes M to XML (compact or indented per SerializationFormat), assembles a two-part RADIO/DISH message [group=topic, payload=XML], and sends via the shared ZmqAsb write channel. Close is a no-op — channel is shared with ZmqAsb. CERTs realized: CAL-005368, CAL-005369, CAL-016043.</documentation>
+        <documentation>Concrete AbstractWriter for the ZMQ transport. Delegates serialization to Arc(dyn Externalizer(M)) (replacing hardcoded SerializationFormat). Assembles a two-part RADIO/DISH message [group=topic, payload=serialized bytes], and sends via the shared ZmqAsb write channel. Close is a no-op — channel is shared with ZmqAsb. CERTs realized: CAL-005368, CAL-005369, CAL-016043.</documentation>
       </element>
       <element xsi:type="archimate:ApplicationComponent" name="ZmqReader(M)" id="e-zmqreader">
-        <documentation>Concrete AbstractReader for the ZMQ transport. Owns a DISH socket in a background tokio task that connects to registered peer RADIO URIs and joins the topic group. Dispatches to registered MessageListeners (callback mode) or buffers in a std::sync::mpsc channel (polling mode). Callback and polling modes are mutually exclusive (CAL-016050). Close aborts the background task. CERTs realized: CAL-005378, CAL-005379, CAL-005380, CAL-005391, CAL-005392, CAL-005394, CAL-016044, CAL-016045, CAL-016049, CAL-016050, CAL-016052.</documentation>
+        <documentation>Concrete AbstractReader for the ZMQ transport. Delegates deserialization to Arc(dyn Externalizer(M)) (replacing hardcoded SerializationFormat). Owns a DISH socket in a background tokio task that connects to registered peer RADIO URIs and joins the topic group. Dispatches to registered MessageListeners (callback mode) or buffers in a std::sync::mpsc channel (polling mode). Callback and polling modes are mutually exclusive (CAL-016050). Close aborts the background task. CERTs realized: CAL-005378, CAL-005379, CAL-005380, CAL-005391, CAL-005392, CAL-005394, CAL-016044, CAL-016045, CAL-016049, CAL-016050, CAL-016052.</documentation>
       </element>
       <element xsi:type="archimate:DataObject" name="SerializationFormat" id="e-serformat">
-        <documentation>Enum controlling XML serialization style on a ZMQ transport. Variants: Xml (compact, no whitespace), PrettyXml (indented, human-readable). Configured per transport via the 'format' key in [[transport]] TOML. Default: Xml.</documentation>
+        <documentation>Enum controlling XML serialization style. Variants: Xml (compact, no whitespace), PrettyXml (indented, human-readable). Configured per transport via the 'format' key in [[transport]] TOML. Default: Xml. Now stored in XmlExternalizer rather than directly in ZmqWriter/ZmqReader.</documentation>
       </element>
     </folder>
   </folder>
@@ -190,6 +204,14 @@
     <element xsi:type="archimate:CompositionRelationship" id="r-qos-expiration" source="e-topicqos" target="e-expiration"/>
     <element xsi:type="archimate:CompositionRelationship" id="r-qos-reliability" source="e-topicqos" target="e-reliability"/>
     <element xsi:type="archimate:CompositionRelationship" id="r-qos-tbf" source="e-topicqos" target="e-tbf"/>
+    <!-- Externalizer interfaces -->
+    <element xsi:type="archimate:AssociationRelationship" id="r-ext-calmessage" source="e-externalizer" target="e-calmessage"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-extloader-ext" source="e-extloader" target="e-externalizer"/>
+    <!-- XmlExternalizer/XmlExternalizerLoader realizations -->
+    <element xsi:type="archimate:RealizationRelationship" id="r-xmlext-real" source="e-xmlext" target="e-externalizer"/>
+    <element xsi:type="archimate:RealizationRelationship" id="r-xmlextloader-real" source="e-xmlextloader" target="e-extloader"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-xmlext-serformat" source="e-xmlext" target="e-serformat"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-xmlextloader-xmlext" source="e-xmlextloader" target="e-xmlext"/>
     <!-- ZMQ implementation -->
     <element xsi:type="archimate:RealizationRelationship" id="r-zmqasb-real-asb" source="e-zmqasb" target="e-asb"/>
     <element xsi:type="archimate:RealizationRelationship" id="r-zmqasb-real-cal" source="e-zmqasb" target="e-abstractcal"/>
@@ -199,6 +221,9 @@
     <element xsi:type="archimate:AssociationRelationship" id="r-zmqasb-writer" source="e-zmqasb" target="e-zmqwriter"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-zmqasb-reader" source="e-zmqasb" target="e-zmqreader"/>
     <element xsi:type="archimate:AssociationRelationship" id="r-zmqasb-serformat" source="e-zmqasb" target="e-serformat"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-zmqwriter-ext" source="e-zmqwriter" target="e-externalizer"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-zmqreader-ext" source="e-zmqreader" target="e-externalizer"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-zmqasb-xmlextloader" source="e-zmqasb" target="e-xmlextloader"/>
     <!-- CERT realizations: AbstractServiceBusExt -->
     <element xsi:type="archimate:RealizationRelationship" id="r-asbext-c005364" source="e-asbext" target="req-cal-005364"/>
     <element xsi:type="archimate:RealizationRelationship" id="r-asbext-c005374" source="e-asbext" target="req-cal-005374"/>

--- a/rcal/Cargo.toml
+++ b/rcal/Cargo.toml
@@ -18,6 +18,7 @@ description = "OMS Critical Abstraction Layer (CAL) implementation for Rust"
 [features]
 service = []
 zmq = ["dep:omq-tokio"]
+compression = ["dep:flate2"]
 default = ["service", "zmq"]
 
 [dependencies]
@@ -33,6 +34,7 @@ slog-term = "2.9.2"
 toml = "1.1.4"
 uuid = { version = "1.24.0", features = ["v1", "v3", "v4", "slog", "serde", "rng"] }
 omq-tokio = { version = "0.21.1", optional = true }
+flate2 = { version = "1", optional = true }
 tokio = { version = "1.53.1", features = ["full"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
 chrono = { version = "0.4.45", features = ["serde"] }
@@ -53,6 +55,10 @@ name = "basic"
 
 [[example]]
 name = "custom_tokio"
+
+[[example]]
+name = "xml_gzip"
+required-features = ["compression"]
 
 [[test]]
 name = "zmq_radio_dish"

--- a/rcal/examples/CALConfig.toml
+++ b/rcal/examples/CALConfig.toml
@@ -15,7 +15,11 @@ level = "info"
 id = "main-bus"
 type = "zmq"
 uri = "tcp://127.0.0.1:2100"
-format = "pretty_xml"
+externalizer = "pretty_xml"
+
+[externalizer.pretty_xml]
+type = "xml"
+pretty = true
 
 [[service]]
 id = "basic-example"

--- a/rcal/examples/system_status.rs
+++ b/rcal/examples/system_status.rs
@@ -34,6 +34,15 @@ async fn main() {
         .unwrap_or_else(|| panic!("transport '{transport_id}' not in config"))
         .clone();
 
+    // Determine pretty-print flag before config is moved into ZmqAsb.
+    let pretty = {
+        let ext_name = tconfig.externalizer.as_deref().unwrap_or("xml");
+        matches!(
+            config.externalizer.get(ext_name),
+            Some(rcal::calconfig::ExternalizerConfig::Xml { pretty: true })
+        )
+    };
+
     let mut bus = ZmqAsb::new(
         "SystemStatusExample",
         transport_id,
@@ -61,7 +70,6 @@ async fn main() {
 
     // Spawn a blocking thread: read → validate → print XML.
     // Loop exits when the ASB closes (Err return from read).
-    let pretty = tconfig.format == rcal::uci::base::SerializationFormat::PrettyXml;
     let reader_handle = tokio::task::spawn_blocking(move || {
         let expected_type = SystemStatus_::message_type_name();
         loop {

--- a/rcal/examples/xml_gzip.rs
+++ b/rcal/examples/xml_gzip.rs
@@ -11,8 +11,7 @@ use std::collections::HashMap;
 use rcal::calconfig::SerializationFormat;
 use rcal::calconfig::{CalConfig, CompressionType, ExternalizerConfig};
 use rcal::externalizer::{
-    CompressionExternalizer, Externalizer, XML_GZIP_EXTERNALIZER_ENCODING, XmlExternalizer,
-    build_externalizer, new_gzip_externalizer,
+    XmlExternalizer, build_externalizer, new_gzip_externalizer, read_from_bytes, write_to_bytes,
 };
 use rcal::uci::CalMessage;
 use rcal::uci::types::SystemStatus_;
@@ -22,23 +21,18 @@ fn main() {
     let msg = SystemStatus_::cal_create();
 
     // ── 1. Direct construction ────────────────────────────────────────────────
-    let inner: Box<dyn Externalizer<SystemStatus_>> =
-        Box::new(XmlExternalizer::new(SerializationFormat::Xml, root.clone()));
-    let gzip_ext: CompressionExternalizer<SystemStatus_> = new_gzip_externalizer(inner);
+    let xml_ext = XmlExternalizer::new(SerializationFormat::Xml);
+    let gzip_ext = new_gzip_externalizer(Box::new(XmlExternalizer::new(SerializationFormat::Xml)));
 
-    let compressed = gzip_ext.write_to_bytes(&msg).expect("serialize failed");
-    let raw_len = XmlExternalizer::new(SerializationFormat::Xml, root.clone())
-        .write_to_bytes(&msg)
-        .unwrap()
-        .len();
+    let compressed = write_to_bytes(&gzip_ext, &msg, &root).expect("serialize failed");
+    let raw_len = write_to_bytes(&xml_ext, &msg, &root).unwrap().len();
     println!(
         "Direct gzip: {} bytes (raw XML: {} bytes)",
         compressed.len(),
         raw_len
     );
-    let _decoded: SystemStatus_ = gzip_ext
-        .read_from_bytes(&compressed)
-        .expect("deserialize failed");
+    let _decoded: SystemStatus_ =
+        read_from_bytes(&gzip_ext, &compressed).expect("deserialize failed");
 
     // ── 2. Config-driven via named externalizer section ───────────────────────
     //
@@ -63,39 +57,20 @@ fn main() {
         },
     );
 
-    let config_ext: Box<dyn Externalizer<SystemStatus_>> =
-        build_externalizer("gzip_xml", &config, root.clone()).expect("build failed");
-    let compressed2 = config_ext
-        .write_to_bytes(&msg)
-        .expect("config ext serialize failed");
-    let _decoded2: SystemStatus_ = config_ext
-        .read_from_bytes(&compressed2)
-        .expect("config ext deserialize failed");
+    let config_ext = build_externalizer("gzip_xml", &config).expect("build failed");
+    let compressed2 =
+        write_to_bytes(config_ext.as_ref(), &msg, &root).expect("config ext serialize failed");
+    let _decoded2: SystemStatus_ =
+        read_from_bytes::<SystemStatus_>(config_ext.as_ref(), &compressed2)
+            .expect("config ext deserialize failed");
     println!("Config-driven gzip_xml: {} bytes", compressed2.len());
 
     // ── 3. "compression" built-in (no config section needed) ─────────────────
-    let builtin_ext: Box<dyn Externalizer<SystemStatus_>> =
-        build_externalizer("compression", &CalConfig::default(), root.clone())
-            .expect("builtin build failed");
-    let compressed3 = builtin_ext
-        .write_to_bytes(&msg)
-        .expect("builtin serialize failed");
+    let builtin_ext =
+        build_externalizer("compression", &CalConfig::default()).expect("builtin build failed");
+    let compressed3 =
+        write_to_bytes(builtin_ext.as_ref(), &msg, &root).expect("builtin serialize failed");
     println!("Built-in \"compression\": {} bytes", compressed3.len());
-
-    // ── 4. Via ExternalizerLoader encoding string "xml+gzip" ──────────────────
-    use rcal::externalizer::{ExternalizerLoader, XmlExternalizerLoader};
-    let loader = XmlExternalizerLoader;
-    let loader_ext: Box<dyn Externalizer<SystemStatus_>> = loader
-        .get_externalizer(XML_GZIP_EXTERNALIZER_ENCODING, "2.5", "1.0")
-        .expect("loader failed");
-    let compressed4 = loader_ext
-        .write_to_bytes(&msg)
-        .expect("loader serialize failed");
-    println!(
-        "ExternalizerLoader \"{}\": {} bytes",
-        XML_GZIP_EXTERNALIZER_ENCODING,
-        compressed4.len()
-    );
 
     println!("All xml+gzip round-trips OK");
 }

--- a/rcal/examples/xml_gzip.rs
+++ b/rcal/examples/xml_gzip.rs
@@ -1,0 +1,101 @@
+//! xml_gzip example — round-trip a UCI message through XML + gzip compression.
+//!
+//! Shows both direct API usage and config-driven externalizer construction via
+//! [`build_externalizer`].
+//!
+//! Run:
+//!   cargo run --example xml_gzip --features compression
+
+use std::collections::HashMap;
+
+use rcal::calconfig::SerializationFormat;
+use rcal::calconfig::{CalConfig, CompressionType, ExternalizerConfig};
+use rcal::externalizer::{
+    CompressionExternalizer, Externalizer, XML_GZIP_EXTERNALIZER_ENCODING, XmlExternalizer,
+    build_externalizer, new_gzip_externalizer,
+};
+use rcal::uci::CalMessage;
+use rcal::uci::types::SystemStatus_;
+
+fn main() {
+    let root = SystemStatus_::message_type_name().local().to_string();
+    let msg = SystemStatus_::cal_create();
+
+    // ── 1. Direct construction ────────────────────────────────────────────────
+    let inner: Box<dyn Externalizer<SystemStatus_>> =
+        Box::new(XmlExternalizer::new(SerializationFormat::Xml, root.clone()));
+    let gzip_ext: CompressionExternalizer<SystemStatus_> = new_gzip_externalizer(inner);
+
+    let compressed = gzip_ext.write_to_bytes(&msg).expect("serialize failed");
+    let raw_len = XmlExternalizer::new(SerializationFormat::Xml, root.clone())
+        .write_to_bytes(&msg)
+        .unwrap()
+        .len();
+    println!(
+        "Direct gzip: {} bytes (raw XML: {} bytes)",
+        compressed.len(),
+        raw_len
+    );
+    let _decoded: SystemStatus_ = gzip_ext
+        .read_from_bytes(&compressed)
+        .expect("deserialize failed");
+
+    // ── 2. Config-driven via named externalizer section ───────────────────────
+    //
+    // Equivalent TOML:
+    //   [externalizer.gzip_xml]
+    //   type = "compression"
+    //   inner = "xml"
+    //   compression_type = "gzip"
+    //   [externalizer.gzip_xml.options]
+    //   level = 6
+    let mut config = CalConfig::default();
+    config.externalizer.insert(
+        "gzip_xml".to_string(),
+        ExternalizerConfig::Compression {
+            inner: "xml".to_string(),
+            compression_type: CompressionType::Gzip,
+            options: {
+                let mut m = HashMap::new();
+                m.insert("level".to_string(), toml::Value::Integer(6));
+                m
+            },
+        },
+    );
+
+    let config_ext: Box<dyn Externalizer<SystemStatus_>> =
+        build_externalizer("gzip_xml", &config, root.clone()).expect("build failed");
+    let compressed2 = config_ext
+        .write_to_bytes(&msg)
+        .expect("config ext serialize failed");
+    let _decoded2: SystemStatus_ = config_ext
+        .read_from_bytes(&compressed2)
+        .expect("config ext deserialize failed");
+    println!("Config-driven gzip_xml: {} bytes", compressed2.len());
+
+    // ── 3. "compression" built-in (no config section needed) ─────────────────
+    let builtin_ext: Box<dyn Externalizer<SystemStatus_>> =
+        build_externalizer("compression", &CalConfig::default(), root.clone())
+            .expect("builtin build failed");
+    let compressed3 = builtin_ext
+        .write_to_bytes(&msg)
+        .expect("builtin serialize failed");
+    println!("Built-in \"compression\": {} bytes", compressed3.len());
+
+    // ── 4. Via ExternalizerLoader encoding string "xml+gzip" ──────────────────
+    use rcal::externalizer::{ExternalizerLoader, XmlExternalizerLoader};
+    let loader = XmlExternalizerLoader;
+    let loader_ext: Box<dyn Externalizer<SystemStatus_>> = loader
+        .get_externalizer(XML_GZIP_EXTERNALIZER_ENCODING, "2.5", "1.0")
+        .expect("loader failed");
+    let compressed4 = loader_ext
+        .write_to_bytes(&msg)
+        .expect("loader serialize failed");
+    println!(
+        "ExternalizerLoader \"{}\": {} bytes",
+        XML_GZIP_EXTERNALIZER_ENCODING,
+        compressed4.len()
+    );
+
+    println!("All xml+gzip round-trips OK");
+}

--- a/rcal/src/asb/zmq.rs
+++ b/rcal/src/asb/zmq.rs
@@ -16,8 +16,8 @@ use crate::cal::{
     AbstractCal, AbstractCalExt, AbstractReader, AbstractWriter, MessageHeaderDefaults,
     MessageListener, TopicQos,
 };
-use crate::calconfig::{CalConfig, SerializationFormat, Transport};
-use crate::externalizer::{Externalizer, XmlExternalizer};
+use crate::calconfig::{CalConfig, Transport};
+use crate::externalizer::{Externalizer, build_externalizer};
 use crate::uci::{CalError, CalErrorKind, CalImplementationErrorKind, CalMessage, CalResult};
 use serde::Deserialize as _;
 use serde::de::IntoDeserializer;
@@ -104,8 +104,8 @@ pub struct ZmqAsb {
     /// Populate with [`add_receive_peer`] for multi-process topologies.
     peer_uris: Vec<String>,
 
-    /// Serialization format for messages on this transport.
-    serialization_format: SerializationFormat,
+    /// Externalizer name for messages on this transport (references `CalConfig::externalizer`).
+    externalizer_name: String,
 
     /// Registered connection-status listeners.
     listeners: Vec<Arc<dyn AsbStatusListener>>,
@@ -180,7 +180,10 @@ impl ZmqAsb {
             config,
             transport_uri,
             peer_uris: Vec::new(),
-            serialization_format: tconfig.format.clone(),
+            externalizer_name: tconfig
+                .externalizer
+                .clone()
+                .unwrap_or_else(|| "xml".to_string()),
             listeners: Vec::new(),
             shutdown_tx,
             #[cfg(test)]
@@ -435,9 +438,9 @@ impl<M: CalMessage + serde::Serialize> AbstractWriter<M> for ZmqWriter<M> {
                 "message failed schema validation",
             )
         })?;
-        let xml = self.externalizer.write_to_string(message)?;
+        let payload = self.externalizer.write_to_bytes(message)?;
         // RADIO/DISH: part[0] = group (topic for DISH filtering), part[1] = payload
-        let msg = Message::multipart([self.topic.clone(), xml]);
+        let msg = Message::multipart([self.topic.as_bytes().to_vec(), payload]);
         match &self.writer_buf {
             Some(buf) => {
                 let max = self.writer_max.unwrap();
@@ -660,10 +663,11 @@ where
             (Some(tx), None, None, None)
         };
 
-        let externalizer: Arc<dyn Externalizer<M>> = Arc::new(XmlExternalizer::new(
-            self.serialization_format.clone(),
+        let externalizer: Arc<dyn Externalizer<M>> = Arc::from(build_externalizer(
+            &self.externalizer_name,
+            &self.config,
             cal_topic.to_string(),
-        ));
+        )?);
         trace!(self.logger, "ZmqAsb::create_writer()"; "topic" => cal_topic);
         Ok(Box::new(ZmqWriter {
             topic: cal_topic.to_string(),
@@ -715,10 +719,11 @@ where
         let poll_state_task = Arc::clone(&poll_state);
         let task_alive_task = Arc::clone(&task_alive);
         let topic_str = cal_topic.to_string();
-        let externalizer: Arc<dyn Externalizer<M>> = Arc::new(XmlExternalizer::new(
-            self.serialization_format.clone(),
+        let externalizer: Arc<dyn Externalizer<M>> = Arc::from(build_externalizer(
+            &self.externalizer_name,
+            &self.config,
             cal_topic.to_string(),
-        ));
+        )?);
         let ext_task = Arc::clone(&externalizer);
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         let reader_logger = self.logger.new(slog::o!("topic" => cal_topic.to_string()));
@@ -1347,7 +1352,7 @@ mod tests {
         let ns = UUID::parse_str(BASE_UUID).unwrap();
         let sys_uuid = UUID::generate_v3(&ns, port.to_string().as_bytes());
         let toml = format!(
-            "[system]\nid = \"TestSystem\"\nlabel = \"OMS Test System\"\nuuid = \"{sys_uuid}\"\ndefault_transport = \"TestZmq\"\n\n[[transport]]\nid = \"TestZmq\"\ntype = \"zmq\"\nuri = \"tcp://127.0.0.1:{port}\"\nformat = \"pretty_xml\"\n"
+            "[system]\nid = \"TestSystem\"\nlabel = \"OMS Test System\"\nuuid = \"{sys_uuid}\"\ndefault_transport = \"TestZmq\"\n\n[[transport]]\nid = \"TestZmq\"\ntype = \"zmq\"\nuri = \"tcp://127.0.0.1:{port}\"\nexternalizer = \"pretty\"\n\n[externalizer.pretty]\ntype = \"xml\"\npretty = true\n"
         );
         let config = Arc::new(calconfig::parse_config(&toml).unwrap());
         let tconfig = config.get_transport(&String::from("TestZmq")).unwrap();

--- a/rcal/src/asb/zmq.rs
+++ b/rcal/src/asb/zmq.rs
@@ -17,36 +17,13 @@ use crate::cal::{
     MessageListener, TopicQos,
 };
 use crate::calconfig::{CalConfig, SerializationFormat, Transport};
+use crate::externalizer::{Externalizer, XmlExternalizer};
 use crate::uci::{CalError, CalErrorKind, CalImplementationErrorKind, CalMessage, CalResult};
 use serde::Deserialize as _;
 use serde::de::IntoDeserializer;
 
 /// ASB identifier string for the ZeroMQ-compatible transport.
 pub const ZMQ_ASB_ID: &str = "zmq";
-
-// ════════════════════════════════════════════════════════════════════════════
-// Serialization helpers
-// ════════════════════════════════════════════════════════════════════════════
-
-fn serialize_message<M: serde::Serialize>(
-    msg: &M,
-    root: &str,
-    format: &SerializationFormat,
-) -> CalResult<String> {
-    match format {
-        SerializationFormat::Xml => quick_xml::se::to_string_with_root(root, msg)
-            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string())),
-        SerializationFormat::PrettyXml => {
-            let mut buf = String::new();
-            let mut ser = quick_xml::se::Serializer::with_root(&mut buf, Some(root))
-                .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
-            ser.indent(' ', 4);
-            msg.serialize(ser)
-                .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
-            Ok(buf)
-        }
-    }
-}
 
 /// Validates that message type `M` matches the topic's registered type in
 /// the service config, if one is configured. No-op when the service or topic
@@ -89,13 +66,6 @@ fn resolve_topic<'a>(config: &'a CalConfig, service_id: &str, topic: &'a str) ->
         .and_then(|s| s.topic.iter().find(|t| t.id == topic))
         .and_then(|t| t.topic.as_deref())
         .unwrap_or(topic)
-}
-
-fn deserialize_message<M: serde::de::DeserializeOwned>(xml: &[u8]) -> CalResult<M> {
-    let xml_str = std::str::from_utf8(xml)
-        .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
-    quick_xml::de::from_str(xml_str)
-        .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -443,7 +413,7 @@ type PollState<M> = Arc<(Mutex<VecDeque<(Instant, Arc<M>)>>, Condvar)>;
 pub struct ZmqWriter<M: CalMessage> {
     topic: String,
     logger: Logger,
-    format: SerializationFormat,
+    externalizer: Arc<dyn Externalizer<M>>,
     direct_tx: Option<tokio::sync::mpsc::UnboundedSender<Message>>,
     writer_buf: Option<Arc<Mutex<VecDeque<Message>>>>,
     writer_notify: Option<Arc<tokio::sync::Notify>>,
@@ -465,7 +435,7 @@ impl<M: CalMessage + serde::Serialize> AbstractWriter<M> for ZmqWriter<M> {
                 "message failed schema validation",
             )
         })?;
-        let xml = serialize_message(message, &self.topic, &self.format)?;
+        let xml = self.externalizer.write_to_string(message)?;
         // RADIO/DISH: part[0] = group (topic for DISH filtering), part[1] = payload
         let msg = Message::multipart([self.topic.clone(), xml]);
         match &self.writer_buf {
@@ -532,6 +502,7 @@ impl<M: CalMessage + serde::Serialize> AbstractWriter<M> for ZmqWriter<M> {
 pub struct ZmqReader<M: CalMessage> {
     topic: String,
     logger: Logger,
+    externalizer: Arc<dyn Externalizer<M>>,
     listeners: Arc<Mutex<Vec<Arc<dyn MessageListener<M>>>>>,
     /// Shared queue + condvar for poll-mode delivery with expiration support.
     poll_state: PollState<M>,
@@ -689,11 +660,15 @@ where
             (Some(tx), None, None, None)
         };
 
+        let externalizer: Arc<dyn Externalizer<M>> = Arc::new(XmlExternalizer::new(
+            self.serialization_format.clone(),
+            cal_topic.to_string(),
+        ));
         trace!(self.logger, "ZmqAsb::create_writer()"; "topic" => cal_topic);
         Ok(Box::new(ZmqWriter {
             topic: cal_topic.to_string(),
             logger: self.logger.new(slog::o!("topic" => cal_topic.to_string())),
-            format: self.serialization_format.clone(),
+            externalizer,
             direct_tx,
             writer_buf,
             writer_notify,
@@ -740,7 +715,11 @@ where
         let poll_state_task = Arc::clone(&poll_state);
         let task_alive_task = Arc::clone(&task_alive);
         let topic_str = cal_topic.to_string();
-        let _format = self.serialization_format.clone(); // ponytail: deserialization is format-agnostic (XML only); extend if binary formats are added
+        let externalizer: Arc<dyn Externalizer<M>> = Arc::new(XmlExternalizer::new(
+            self.serialization_format.clone(),
+            cal_topic.to_string(),
+        ));
+        let ext_task = Arc::clone(&externalizer);
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         let reader_logger = self.logger.new(slog::o!("topic" => cal_topic.to_string()));
 
@@ -766,7 +745,7 @@ where
                     _ = shutdown_rx.changed() => break,
                 };
                 let payload = raw.part_bytes(1).unwrap_or_default();
-                let m = match deserialize_message::<M>(&payload) {
+                let m = match ext_task.read_from_bytes(&payload) {
                     Ok(m) => m,
                     Err(e) => {
                         slog::warn!(reader_logger, "deserialize failed"; "error" => %e);
@@ -813,6 +792,7 @@ where
         Ok(Box::new(ZmqReader {
             topic: topic.to_string(),
             logger: self.logger.new(slog::o!("topic" => topic.to_string())),
+            externalizer,
             listeners,
             poll_state,
             task_alive,

--- a/rcal/src/asb/zmq.rs
+++ b/rcal/src/asb/zmq.rs
@@ -17,7 +17,7 @@ use crate::cal::{
     MessageListener, TopicQos,
 };
 use crate::calconfig::{CalConfig, Transport};
-use crate::externalizer::{Externalizer, build_externalizer};
+use crate::externalizer::{Externalizer, build_externalizer, read_from_bytes, write_to_bytes};
 use crate::uci::{CalError, CalErrorKind, CalImplementationErrorKind, CalMessage, CalResult};
 use serde::Deserialize as _;
 use serde::de::IntoDeserializer;
@@ -416,7 +416,7 @@ type PollState<M> = Arc<(Mutex<VecDeque<(Instant, Arc<M>)>>, Condvar)>;
 pub struct ZmqWriter<M: CalMessage> {
     topic: String,
     logger: Logger,
-    externalizer: Arc<dyn Externalizer<M>>,
+    externalizer: Arc<dyn Externalizer>,
     direct_tx: Option<tokio::sync::mpsc::UnboundedSender<Message>>,
     writer_buf: Option<Arc<Mutex<VecDeque<Message>>>>,
     writer_notify: Option<Arc<tokio::sync::Notify>>,
@@ -438,7 +438,7 @@ impl<M: CalMessage + serde::Serialize> AbstractWriter<M> for ZmqWriter<M> {
                 "message failed schema validation",
             )
         })?;
-        let payload = self.externalizer.write_to_bytes(message)?;
+        let payload = write_to_bytes(self.externalizer.as_ref(), message, &self.topic)?;
         // RADIO/DISH: part[0] = group (topic for DISH filtering), part[1] = payload
         let msg = Message::multipart([self.topic.as_bytes().to_vec(), payload]);
         match &self.writer_buf {
@@ -505,7 +505,7 @@ impl<M: CalMessage + serde::Serialize> AbstractWriter<M> for ZmqWriter<M> {
 pub struct ZmqReader<M: CalMessage> {
     topic: String,
     logger: Logger,
-    externalizer: Arc<dyn Externalizer<M>>,
+    externalizer: Arc<dyn Externalizer>,
     listeners: Arc<Mutex<Vec<Arc<dyn MessageListener<M>>>>>,
     /// Shared queue + condvar for poll-mode delivery with expiration support.
     poll_state: PollState<M>,
@@ -663,11 +663,8 @@ where
             (Some(tx), None, None, None)
         };
 
-        let externalizer: Arc<dyn Externalizer<M>> = Arc::from(build_externalizer(
-            &self.externalizer_name,
-            &self.config,
-            cal_topic.to_string(),
-        )?);
+        let externalizer: Arc<dyn Externalizer> =
+            Arc::from(build_externalizer(&self.externalizer_name, &self.config)?);
         trace!(self.logger, "ZmqAsb::create_writer()"; "topic" => cal_topic);
         Ok(Box::new(ZmqWriter {
             topic: cal_topic.to_string(),
@@ -719,11 +716,8 @@ where
         let poll_state_task = Arc::clone(&poll_state);
         let task_alive_task = Arc::clone(&task_alive);
         let topic_str = cal_topic.to_string();
-        let externalizer: Arc<dyn Externalizer<M>> = Arc::from(build_externalizer(
-            &self.externalizer_name,
-            &self.config,
-            cal_topic.to_string(),
-        )?);
+        let externalizer: Arc<dyn Externalizer> =
+            Arc::from(build_externalizer(&self.externalizer_name, &self.config)?);
         let ext_task = Arc::clone(&externalizer);
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         let reader_logger = self.logger.new(slog::o!("topic" => cal_topic.to_string()));
@@ -750,7 +744,7 @@ where
                     _ = shutdown_rx.changed() => break,
                 };
                 let payload = raw.part_bytes(1).unwrap_or_default();
-                let m = match ext_task.read_from_bytes(&payload) {
+                let m = match read_from_bytes::<M>(ext_task.as_ref(), &payload) {
                     Ok(m) => m,
                     Err(e) => {
                         slog::warn!(reader_logger, "deserialize failed"; "error" => %e);

--- a/rcal/src/calconfig/mod.rs
+++ b/rcal/src/calconfig/mod.rs
@@ -2,6 +2,7 @@
 use crate::uci::base::UUID;
 use crate::uci::{CalError, CalImplementationErrorKind, CalResult};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt;
 use std::fs;
 
@@ -13,6 +14,12 @@ pub struct CalConfig {
     pub uuidfactory: UUIDFactory,
     pub transport: Vec<Transport>,
     pub service: Vec<Service>,
+    /// Named externalizer configurations.
+    ///
+    /// Use the short built-in names `"xml"` or (with feature `compression`) `"compression"`
+    /// without a section for defaults.  Add a `[externalizer.<name>]` section to override
+    /// options or to define a named chain.
+    pub externalizer: HashMap<String, ExternalizerConfig>,
 }
 
 impl CalConfig {
@@ -162,7 +169,10 @@ pub struct UUIDFactory {
     pub node: Option<mac_address::MacAddress>,
 }
 
-/// Serialization format used for CAL Messages on a transport.
+/// Serialization format used internally by [`XmlExternalizer`][crate::externalizer::XmlExternalizer].
+///
+/// This type controls XML whitespace only.  Transport-level externalizer selection
+/// is configured via [`Transport::externalizer`] and [`CalConfig::externalizer`].
 #[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SerializationFormat {
@@ -173,6 +183,69 @@ pub enum SerializationFormat {
     PrettyXml,
 }
 
+/// Configuration for a named externalizer.
+///
+/// Reference the name in [`Transport::externalizer`].
+/// Built-in names (`"xml"`, and with feature `compression`: `"compression"`) work
+/// without a section entry; add a section only to override defaults or build a chain.
+///
+/// # Examples (TOML)
+/// ```toml
+/// [externalizer.pretty]
+/// type = "xml"
+/// pretty = true
+///
+/// [externalizer.gzip_xml]
+/// type = "compression"
+/// inner = "xml"          # which externalizer to wrap (default: "xml")
+/// compression_type = "gzip"   # gzip | deflate | zlib  (default: "gzip")
+/// [externalizer.gzip_xml.options]
+/// level = 6              # 0–9, default per algorithm
+/// ```
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ExternalizerConfig {
+    /// XML serialization.
+    Xml {
+        /// Use indented, human-readable XML (default: `false`).
+        #[serde(default)]
+        pretty: bool,
+    },
+    /// Byte-level compression chain wrapping an inner externalizer.
+    ///
+    /// Requires the `compression` feature.
+    #[cfg(feature = "compression")]
+    Compression {
+        /// Name of the inner externalizer to wrap (default: `"xml"`).
+        #[serde(default = "default_inner_externalizer")]
+        inner: String,
+        /// Compression algorithm (default: `"gzip"`).
+        #[serde(default)]
+        compression_type: CompressionType,
+        /// Algorithm-specific options (e.g. `level = 6`).
+        #[serde(default)]
+        options: HashMap<String, toml::Value>,
+    },
+}
+
+#[cfg(feature = "compression")]
+fn default_inner_externalizer() -> String {
+    "xml".to_string()
+}
+
+/// Compression algorithm for [`ExternalizerConfig::Compression`].
+///
+/// All variants are enabled by `flate2`'s default features.
+#[cfg(feature = "compression")]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CompressionType {
+    #[default]
+    Gzip,
+    Deflate,
+    Zlib,
+}
+
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 #[serde(default)]
 pub struct Transport {
@@ -180,8 +253,11 @@ pub struct Transport {
     #[serde(rename = "type")]
     pub type_: String,
     pub uri: String,
-    /// Serialization format for CAL Messages on this transport (default: `xml`).
-    pub format: SerializationFormat,
+    /// Name of the externalizer to use for this transport (default: `"xml"`).
+    ///
+    /// Use a built-in name (`"xml"`, `"compression"`) or reference a
+    /// `[externalizer.<name>]` section in `CalConfig`.
+    pub externalizer: Option<String>,
 }
 
 /// A name-to-UUID mapping used for components and capabilities (CAL-005203).

--- a/rcal/src/calconfig/mod.rs
+++ b/rcal/src/calconfig/mod.rs
@@ -173,7 +173,7 @@ pub struct UUIDFactory {
 ///
 /// This type controls XML whitespace only.  Transport-level externalizer selection
 /// is configured via [`Transport::externalizer`] and [`CalConfig::externalizer`].
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SerializationFormat {
     /// Whitespace-compressed XML (default).
@@ -226,6 +226,31 @@ pub enum ExternalizerConfig {
         #[serde(default)]
         options: HashMap<String, toml::Value>,
     },
+}
+
+#[cfg(feature = "compression")]
+impl CompressionType {
+    /// Returns the string identifier for this compression type.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Gzip => "gzip",
+            Self::Deflate => "deflate",
+            Self::Zlib => "zlib",
+        }
+    }
+}
+
+#[cfg(feature = "compression")]
+impl std::str::FromStr for CompressionType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gzip" => Ok(Self::Gzip),
+            "deflate" => Ok(Self::Deflate),
+            "zlib" => Ok(Self::Zlib),
+            _ => Err(()),
+        }
+    }
 }
 
 #[cfg(feature = "compression")]

--- a/rcal/src/externalizer.rs
+++ b/rcal/src/externalizer.rs
@@ -3,53 +3,60 @@
 //! ## Specification references
 //! - OMSC-SPC-008 Rev K §9.13–9.15 (CXX-012071–012446)
 
-#![warn(missing_docs)]
-
 #[cfg(feature = "compression")]
 use crate::calconfig::CompressionType;
 use crate::calconfig::{CalConfig, ExternalizerConfig, SerializationFormat};
 use crate::uci::{CalError, CalErrorKind, CalMessage, CalResult};
+use std::collections::HashMap;
 use std::io::{Read, Write};
 
 // ════════════════════════════════════════════════════════════════════════════
-// Externalizer<M>
+// Externalizer
 // ════════════════════════════════════════════════════════════════════════════
 
-/// Abstract serialization/deserialization interface for a single CAL Message type.
+/// Abstract byte-transform interface for a CAL encoding pipeline.
 ///
-/// Rust equivalent of `uci::base::Externalizer` (OMSC-SPC-008 §9.13).
-/// The trait is generic over `M: CalMessage` so that `dyn Externalizer<M>` is
-/// a valid trait object for any specific message type `M`.
+/// An `Externalizer` performs byte-level encoding/decoding (e.g. compression,
+/// encryption) and reports its identity. It is intentionally message-type-agnostic;
+/// M-specific serialization/deserialization is handled by the free functions
+/// [`write_to_bytes`], [`write_to_string`], [`write_to_writer`],
+/// [`read_from_bytes`], [`read_from_str`], and [`read_from_reader`].
 ///
-/// Obtain instances from an [`ExternalizerLoader`] or construct them directly
-/// (e.g. [`XmlExternalizer`]).
+/// Externalizers may be chained via [`next`][Externalizer::next].
+/// During encoding, the head's [`encode`][Externalizer::encode] is applied first,
+/// then each subsequent node's. During decoding the order is reversed.
+///
+/// Obtain instances via [`ExternalizerLoader`], [`build_externalizer`], or the
+/// [`ExternalizerBuilder`] fluent API.
 ///
 /// # CERT coverage
 /// CXX-012071, CXX-012099, CXX-012115, CXX-012131, CXX-012146, CXX-012161,
 /// CXX-012176, CXX-012238, CXX-012252, CXX-012266, CXX-012280, CXX-012294,
 /// CXX-012688, CXX-012689, CXX-012690, CXX-012691
-pub trait Externalizer<M: CalMessage>: Send + Sync {
-    // ── Read (CXX-012099, 012115, 012131) ───────────────────────────────────
+pub trait Externalizer: Send + Sync {
+    /// Apply the local byte transform (default: identity).
+    fn encode(&self, bytes: &[u8]) -> CalResult<Vec<u8>> {
+        Ok(bytes.to_vec())
+    }
 
-    /// Deserialize a message by reading from `reader` (CXX-012099).
-    fn read_from_reader(&self, reader: &mut dyn Read) -> CalResult<M>;
+    /// Reverse the local byte transform (default: identity).
+    fn decode(&self, bytes: &[u8]) -> CalResult<Vec<u8>> {
+        Ok(bytes.to_vec())
+    }
 
-    /// Deserialize a message from a UTF-8 string (CXX-012115).
-    fn read_from_str(&self, s: &str) -> CalResult<M>;
+    /// Optional next externalizer in the chain. Applied after `self` during encode,
+    /// before `self` during decode.
+    fn next(&self) -> Option<&dyn Externalizer> {
+        None
+    }
 
-    /// Deserialize a message from a byte slice (CXX-012131).
-    fn read_from_bytes(&self, bytes: &[u8]) -> CalResult<M>;
-
-    // ── Write (CXX-012146, 012161, 012176) ──────────────────────────────────
-
-    /// Serialize `msg` and write the bytes to `writer` (CXX-012146).
-    fn write_to_writer(&self, msg: &M, writer: &mut dyn Write) -> CalResult<()>;
-
-    /// Serialize `msg` to a [`String`] (CXX-012161).
-    fn write_to_string(&self, msg: &M) -> CalResult<String>;
-
-    /// Serialize `msg` to a byte vector (CXX-012176).
-    fn write_to_bytes(&self, msg: &M) -> CalResult<Vec<u8>>;
+    /// The serialization format reported by this externalizer, if any.
+    ///
+    /// Leaf externalizers (e.g. [`XmlExternalizer`]) return `Some`; byte-transform
+    /// externalizers (e.g. compression) return `None` and delegate to their `next`.
+    fn serialization_format(&self) -> Option<SerializationFormat> {
+        None
+    }
 
     // ── Version / identity (CXX-012238, 012252, 012266, 012280, 012294) ─────
 
@@ -60,75 +67,196 @@ pub trait Externalizer<M: CalMessage>: Send + Sync {
     fn get_encoding(&self) -> &str;
 
     /// Returns the UCI schema version this externalizer targets (CXX-012266).
-    fn get_schema_version(&self) -> &str;
+    fn get_schema_version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
 
     /// Returns the vendor-specific version string (CXX-012280).
-    fn get_vendor_version(&self) -> &str;
+    fn get_vendor_version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
 
     /// Returns the vendor name (CXX-012294).
-    fn get_vendor(&self) -> &str;
+    fn get_vendor(&self) -> &str {
+        XML_EXTERNALIZER_VENDOR
+    }
 
     // ── Capability queries (CXX-012688–012691) ───────────────────────────────
 
     /// Returns `true` if this externalizer supports read operations only (CXX-012688).
-    fn message_read_only(&self) -> bool;
+    fn message_read_only(&self) -> bool {
+        false
+    }
 
     /// Returns `true` if this externalizer supports write operations only (CXX-012689).
-    fn message_write_only(&self) -> bool;
+    fn message_write_only(&self) -> bool {
+        false
+    }
 
     /// Returns `true` if read operations are supported (CXX-012690).
-    fn supports_object_read(&self) -> bool;
+    fn supports_object_read(&self) -> bool {
+        true
+    }
 
     /// Returns `true` if write operations are supported (CXX-012691).
-    fn supports_object_write(&self) -> bool;
+    fn supports_object_write(&self) -> bool {
+        true
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-// ExternalizerLoader<M>
+// ExternalizerLoader
 // ════════════════════════════════════════════════════════════════════════════
 
 /// Factory for obtaining [`Externalizer`] instances by encoding name.
 ///
 /// Rust equivalent of `uci::base::ExternalizerLoader` (OMSC-SPC-008 §9.14).
-/// `destroy_externalizer` (CXX-012381) is unnecessary in Rust — `Box` drop
-/// handles deallocation.
+/// Drop the returned `Box` to release the loader (no explicit destroy call needed).
 ///
 /// # CERT coverage
 /// CXX-012338, CXX-012367, CXX-012381
-pub trait ExternalizerLoader<M: CalMessage>: Send + Sync {
+pub trait ExternalizerLoader: Send + Sync {
     /// Return a boxed [`Externalizer`] for the requested encoding.
     ///
     /// `encoding` — format identifier, e.g. `"xml"`.
-    /// `schema_version` — target UCI schema version.
-    /// `vendor_version` — implementor-defined version string.
-    ///
-    /// Returns [`CalErrorKind::SerializationError`] if the encoding is not
-    /// supported by this loader (CXX-012367).
+    /// Returns [`CalErrorKind::SerializationError`] for unsupported encodings (CXX-012367).
     fn get_externalizer(
         &self,
         encoding: &str,
         schema_version: &str,
         vendor_version: &str,
-    ) -> CalResult<Box<dyn Externalizer<M>>>;
+    ) -> CalResult<Box<dyn Externalizer>>;
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-// Global free functions (CXX-012434, CXX-012446)
+// Free functions (CXX-012099, 012115, 012131, 012146, 012161, 012176, 012434)
 // ════════════════════════════════════════════════════════════════════════════
 
-/// Return the default [`ExternalizerLoader`] for message type `M` (CXX-012434).
-///
-/// The default loader supports `"xml"` encoding via [`XmlExternalizerLoader`].
-/// To release the loader, simply drop the returned `Box` — no explicit destroy
-/// call is needed (contrast with CXX-012446, which is a C++ memory-management
-/// artefact with no Rust equivalent).
-pub fn get_externalizer_loader<M: CalMessage + serde::Serialize + serde::de::DeserializeOwned>()
--> Box<dyn ExternalizerLoader<M>> {
+/// Return the default [`ExternalizerLoader`] (CXX-012434).
+pub fn get_externalizer_loader() -> Box<dyn ExternalizerLoader> {
     Box::new(XmlExternalizerLoader)
 }
 
+/// Serialize `msg` through the externalizer chain and return bytes (CXX-012176).
+///
+/// `root` sets the XML root element name (typically the topic name).
+pub fn write_to_bytes<M>(ext: &dyn Externalizer, msg: &M, root: &str) -> CalResult<Vec<u8>>
+where
+    M: CalMessage + serde::Serialize,
+{
+    let format = find_format(ext).ok_or_else(|| {
+        CalError::new(
+            CalErrorKind::SerializationError,
+            "no serialization format in externalizer chain",
+        )
+    })?;
+    let raw = serialize_xml(msg, root, format)?;
+    encode_chain(ext, &raw)
+}
+
+/// Serialize `msg` through the externalizer chain and return a `String` (CXX-012161).
+pub fn write_to_string<M>(ext: &dyn Externalizer, msg: &M, root: &str) -> CalResult<String>
+where
+    M: CalMessage + serde::Serialize,
+{
+    write_to_bytes(ext, msg, root).and_then(|b| {
+        String::from_utf8(b)
+            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
+    })
+}
+
+/// Serialize `msg` through the externalizer chain and write to `writer` (CXX-012146).
+pub fn write_to_writer<M>(
+    ext: &dyn Externalizer,
+    msg: &M,
+    root: &str,
+    writer: &mut dyn Write,
+) -> CalResult<()>
+where
+    M: CalMessage + serde::Serialize,
+{
+    let bytes = write_to_bytes(ext, msg, root)?;
+    writer
+        .write_all(&bytes)
+        .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
+}
+
+/// Decode `bytes` through the full externalizer chain and deserialize to `M` (CXX-012131).
+pub fn read_from_bytes<M>(ext: &dyn Externalizer, bytes: &[u8]) -> CalResult<M>
+where
+    M: CalMessage + serde::de::DeserializeOwned,
+{
+    let decoded = decode_chain(ext, bytes)?;
+    quick_xml::de::from_reader(decoded.as_slice())
+        .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
+}
+
+/// Decode `s` through the full externalizer chain and deserialize to `M` (CXX-012115).
+pub fn read_from_str<M>(ext: &dyn Externalizer, s: &str) -> CalResult<M>
+where
+    M: CalMessage + serde::de::DeserializeOwned,
+{
+    read_from_bytes(ext, s.as_bytes())
+}
+
+/// Read all bytes from `reader`, decode through the chain, and deserialize to `M` (CXX-012099).
+pub fn read_from_reader<M>(ext: &dyn Externalizer, reader: &mut dyn Read) -> CalResult<M>
+where
+    M: CalMessage + serde::de::DeserializeOwned,
+{
+    let mut buf = Vec::new();
+    reader
+        .read_to_end(&mut buf)
+        .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
+    read_from_bytes(ext, &buf)
+}
+
+// ── Chain helpers ────────────────────────────────────────────────────────────
+
+fn find_format(ext: &dyn Externalizer) -> Option<SerializationFormat> {
+    ext.serialization_format()
+        .or_else(|| ext.next().and_then(find_format))
+}
+
+fn encode_chain(ext: &dyn Externalizer, bytes: &[u8]) -> CalResult<Vec<u8>> {
+    let encoded = ext.encode(bytes)?;
+    match ext.next() {
+        Some(n) => encode_chain(n, &encoded),
+        None => Ok(encoded),
+    }
+}
+
+fn decode_chain(ext: &dyn Externalizer, bytes: &[u8]) -> CalResult<Vec<u8>> {
+    let bytes = match ext.next() {
+        Some(n) => decode_chain(n, bytes)?,
+        None => bytes.to_vec(),
+    };
+    ext.decode(&bytes)
+}
+
+fn serialize_xml<M: serde::Serialize>(
+    msg: &M,
+    root: &str,
+    format: SerializationFormat,
+) -> CalResult<Vec<u8>> {
+    match format {
+        SerializationFormat::Xml => quick_xml::se::to_string_with_root(root, msg)
+            .map(String::into_bytes)
+            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string())),
+        SerializationFormat::PrettyXml => {
+            let mut buf = String::new();
+            let mut ser = quick_xml::se::Serializer::with_root(&mut buf, Some(root))
+                .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
+            ser.indent(' ', 4);
+            serde::Serialize::serialize(msg, ser)
+                .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
+            Ok(buf.into_bytes())
+        }
+    }
+}
+
 // ════════════════════════════════════════════════════════════════════════════
-// XmlExternalizer
+// Constants
 // ════════════════════════════════════════════════════════════════════════════
 
 /// CAL API version string reported by the XML externalizer.
@@ -138,76 +266,47 @@ pub const XML_EXTERNALIZER_ENCODING: &str = "xml";
 /// Vendor name for this implementation.
 pub const XML_EXTERNALIZER_VENDOR: &str = "rcal";
 
-/// XML-based [`Externalizer`] backed by `quick_xml` / `serde`.
+// ════════════════════════════════════════════════════════════════════════════
+// XmlExternalizer
+// ════════════════════════════════════════════════════════════════════════════
+
+/// XML-format descriptor [`Externalizer`].
 ///
-/// Implements [`Externalizer<M>`] for all `M: CalMessage + serde::Serialize +
-/// serde::de::DeserializeOwned`. The `root` field sets the XML root element
-/// name written by [`write_to_string`][XmlExternalizer::write_to_string];
-/// callers such as [`ZmqWriter`][crate::asb::zmq::ZmqWriter] pass the topic
-/// name here.
+/// Acts as the leaf in an externalizer chain. Its `encode`/`decode` are identity
+/// transforms; it reports a [`SerializationFormat`] so that [`write_to_bytes`] and
+/// related free functions know how to serialize the message type `M`.
+///
+/// Chained byte-transforms (e.g. [`CompressionExternalizer`]) wrap it via `next`.
+///
+/// Construct with [`XmlExternalizer::new`] or via [`ExternalizerBuilder`]:
+/// ```text
+/// builder("xml").kind("xml").build()
+/// ```
 pub struct XmlExternalizer {
     format: SerializationFormat,
-    root: String,
+    /// Optional next byte-transform in the chain.
+    pub next: Option<Box<dyn Externalizer>>,
 }
 
 impl XmlExternalizer {
-    /// Construct a new `XmlExternalizer` with the given format and root element name.
-    pub fn new(format: SerializationFormat, root: impl Into<String>) -> Self {
-        Self {
-            format,
-            root: root.into(),
-        }
+    /// Construct with the given format and no chained externalizer.
+    pub fn new(format: SerializationFormat) -> Self {
+        Self { format, next: None }
+    }
+
+    /// Build from an [`ExternalizerBuilder`].
+    pub fn from_builder(b: &ExternalizerBuilder) -> CalResult<Box<dyn Externalizer>> {
+        Ok(Box::new(xml_from_options(&b.options)))
     }
 }
 
-impl<M> Externalizer<M> for XmlExternalizer
-where
-    M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
-{
-    fn read_from_reader(&self, reader: &mut dyn Read) -> CalResult<M> {
-        let mut buf = Vec::new();
-        reader
-            .read_to_end(&mut buf)
-            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
-        self.read_from_bytes(&buf)
+impl Externalizer for XmlExternalizer {
+    fn next(&self) -> Option<&dyn Externalizer> {
+        self.next.as_deref()
     }
 
-    fn read_from_str(&self, s: &str) -> CalResult<M> {
-        quick_xml::de::from_str(s)
-            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
-    }
-
-    fn read_from_bytes(&self, bytes: &[u8]) -> CalResult<M> {
-        let s = std::str::from_utf8(bytes)
-            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
-        self.read_from_str(s)
-    }
-
-    fn write_to_writer(&self, msg: &M, writer: &mut dyn Write) -> CalResult<()> {
-        let s = self.write_to_string(msg)?;
-        writer
-            .write_all(s.as_bytes())
-            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
-    }
-
-    fn write_to_string(&self, msg: &M) -> CalResult<String> {
-        match self.format {
-            SerializationFormat::Xml => quick_xml::se::to_string_with_root(&self.root, msg)
-                .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string())),
-            SerializationFormat::PrettyXml => {
-                let mut buf = String::new();
-                let mut ser = quick_xml::se::Serializer::with_root(&mut buf, Some(&self.root))
-                    .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
-                ser.indent(' ', 4);
-                serde::Serialize::serialize(msg, ser)
-                    .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
-                Ok(buf)
-            }
-        }
-    }
-
-    fn write_to_bytes(&self, msg: &M) -> CalResult<Vec<u8>> {
-        self.write_to_string(msg).map(String::into_bytes)
+    fn serialization_format(&self) -> Option<SerializationFormat> {
+        Some(self.format)
     }
 
     fn get_cal_api_version(&self) -> &str {
@@ -217,178 +316,107 @@ where
     fn get_encoding(&self) -> &str {
         XML_EXTERNALIZER_ENCODING
     }
-
-    fn get_schema_version(&self) -> &str {
-        // ponytail: returns crate version; replace with schema version constant when defined
-        env!("CARGO_PKG_VERSION")
-    }
-
-    fn get_vendor_version(&self) -> &str {
-        env!("CARGO_PKG_VERSION")
-    }
-
-    fn get_vendor(&self) -> &str {
-        XML_EXTERNALIZER_VENDOR
-    }
-
-    fn message_read_only(&self) -> bool {
-        false
-    }
-
-    fn message_write_only(&self) -> bool {
-        false
-    }
-
-    fn supports_object_read(&self) -> bool {
-        true
-    }
-
-    fn supports_object_write(&self) -> bool {
-        true
-    }
 }
 
-// ════════════════════════════════════════════════════════════════════════════
-// ChainExternalizer<M>
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Byte transform function used by [`ChainExternalizer`].
-type ByteTransform = Box<dyn Fn(&[u8]) -> CalResult<Vec<u8>> + Send + Sync>;
-
-/// Byte-level pipeline wrapper around an [`Externalizer`].
-///
-/// Applies `encode` to serialized bytes before writing, and `decode` to raw
-/// bytes before deserializing. Use this to add compression, encryption, or any
-/// other byte transform without changing the inner externalizer.
-///
-/// **Implicit chaining** is also available: pass a wrapping `impl Write`
-/// (e.g. a gzip encoder) to [`write_to_writer`][Externalizer::write_to_writer]
-/// and a wrapping `impl Read` to [`read_from_reader`][Externalizer::read_from_reader]
-/// directly — no `ChainExternalizer` needed.
-///
-/// # Example (conceptual)
-/// ```text
-/// let chain = ChainExternalizer::new(
-///     Box::new(XmlExternalizer::new(SerializationFormat::Xml, "Msg")),
-///     |bytes| gzip_compress(bytes),
-///     |bytes| gzip_decompress(bytes),
-/// );
-/// // write path: XML → gzip bytes
-/// // read path:  gzip bytes → XML → M
-/// ```
-pub struct ChainExternalizer<M: CalMessage> {
-    inner: Box<dyn Externalizer<M>>,
-    encode: ByteTransform,
-    decode: ByteTransform,
-}
-
-impl<M: CalMessage> ChainExternalizer<M> {
-    /// Construct a chained externalizer.
-    ///
-    /// `encode` transforms bytes *after* serialization (e.g. compress/encrypt).
-    /// `decode` transforms bytes *before* deserialization (e.g. decompress/decrypt).
-    pub fn new(
-        inner: Box<dyn Externalizer<M>>,
-        encode: impl Fn(&[u8]) -> CalResult<Vec<u8>> + Send + Sync + 'static,
-        decode: impl Fn(&[u8]) -> CalResult<Vec<u8>> + Send + Sync + 'static,
-    ) -> Self {
-        Self {
-            inner,
-            encode: Box::new(encode),
-            decode: Box::new(decode),
-        }
-    }
-}
-
-impl<M: CalMessage> Externalizer<M> for ChainExternalizer<M> {
-    fn read_from_reader(&self, reader: &mut dyn Read) -> CalResult<M> {
-        let mut buf = Vec::new();
-        reader
-            .read_to_end(&mut buf)
-            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
-        self.read_from_bytes(&buf)
-    }
-
-    fn read_from_str(&self, s: &str) -> CalResult<M> {
-        self.read_from_bytes(s.as_bytes())
-    }
-
-    fn read_from_bytes(&self, bytes: &[u8]) -> CalResult<M> {
-        let decoded = (self.decode)(bytes)?;
-        self.inner.read_from_bytes(&decoded)
-    }
-
-    fn write_to_writer(&self, msg: &M, writer: &mut dyn Write) -> CalResult<()> {
-        let encoded = self.write_to_bytes(msg)?;
-        writer
-            .write_all(&encoded)
-            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
-    }
-
-    fn write_to_string(&self, msg: &M) -> CalResult<String> {
-        let bytes = self.write_to_bytes(msg)?;
-        String::from_utf8(bytes)
-            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
-    }
-
-    fn write_to_bytes(&self, msg: &M) -> CalResult<Vec<u8>> {
-        let raw = self.inner.write_to_bytes(msg)?;
-        (self.encode)(&raw)
-    }
-
-    fn get_cal_api_version(&self) -> &str {
-        self.inner.get_cal_api_version()
-    }
-
-    fn get_encoding(&self) -> &str {
-        self.inner.get_encoding()
-    }
-
-    fn get_schema_version(&self) -> &str {
-        self.inner.get_schema_version()
-    }
-
-    fn get_vendor_version(&self) -> &str {
-        self.inner.get_vendor_version()
-    }
-
-    fn get_vendor(&self) -> &str {
-        self.inner.get_vendor()
-    }
-
-    fn message_read_only(&self) -> bool {
-        self.inner.message_read_only()
-    }
-
-    fn message_write_only(&self) -> bool {
-        self.inner.message_write_only()
-    }
-
-    fn supports_object_read(&self) -> bool {
-        self.inner.supports_object_read()
-    }
-
-    fn supports_object_write(&self) -> bool {
-        self.inner.supports_object_write()
-    }
+fn xml_from_options(options: &HashMap<String, String>) -> XmlExternalizer {
+    let pretty = options.get("pretty").is_some_and(|v| v == "true");
+    let format = if pretty {
+        SerializationFormat::PrettyXml
+    } else {
+        SerializationFormat::Xml
+    };
+    XmlExternalizer { format, next: None }
 }
 
 // ════════════════════════════════════════════════════════════════════════════
 // CompressionExternalizer (feature = "compression")
 // ════════════════════════════════════════════════════════════════════════════
 
-/// A [`ChainExternalizer`] pre-configured with a compression codec.
+/// Byte-transform [`Externalizer`] that compresses/decompresses using `flate2`.
 ///
-/// Construct with [`new_gzip_externalizer`] or via [`build_externalizer`] with
-/// a `[externalizer.<name>]` section of `type = "compression"` in config.
-///
-/// Requires the `compression` feature.
+/// Requires the `compression` feature. Construct with [`new_gzip_externalizer`]
+/// or via [`ExternalizerBuilder`]:
+/// ```text
+/// builder("xml").kind("xml").chain("gzip").kind("compression").build()
+/// ```
+/// The `next` field holds the inner externalizer (typically [`XmlExternalizer`]).
 #[cfg(feature = "compression")]
-pub type CompressionExternalizer<M> = ChainExternalizer<M>;
+pub struct CompressionExternalizer {
+    compression_type: CompressionType,
+    level: flate2::Compression,
+    /// Optional next externalizer in the chain (inner serializer or further transform).
+    pub next: Option<Box<dyn Externalizer>>,
+}
 
-/// Encoding identifier for XML + gzip (used by [`XmlExternalizerLoader`]).
 #[cfg(feature = "compression")]
-pub const XML_GZIP_EXTERNALIZER_ENCODING: &str = "xml+gzip";
+impl CompressionExternalizer {
+    /// Construct a compression externalizer.
+    ///
+    /// `next` is typically a [`XmlExternalizer`] for message serialization.
+    pub fn new(
+        next: Option<Box<dyn Externalizer>>,
+        compression_type: CompressionType,
+        level: flate2::Compression,
+    ) -> Self {
+        Self {
+            compression_type,
+            level,
+            next,
+        }
+    }
+
+    /// Build from an [`ExternalizerBuilder`], wrapping `next` as the inner externalizer.
+    pub fn from_builder(
+        b: &ExternalizerBuilder,
+        next: Option<Box<dyn Externalizer>>,
+    ) -> CalResult<Box<dyn Externalizer>> {
+        Ok(Box::new(compression_from_options(&b.options, next)))
+    }
+}
+
+#[cfg(feature = "compression")]
+impl Externalizer for CompressionExternalizer {
+    fn encode(&self, bytes: &[u8]) -> CalResult<Vec<u8>> {
+        compress(bytes, self.level, &self.compression_type)
+    }
+
+    fn decode(&self, bytes: &[u8]) -> CalResult<Vec<u8>> {
+        decompress(bytes, &self.compression_type)
+    }
+
+    fn next(&self) -> Option<&dyn Externalizer> {
+        self.next.as_deref()
+    }
+
+    fn get_cal_api_version(&self) -> &str {
+        XML_EXTERNALIZER_CAL_API_VERSION
+    }
+
+    fn get_encoding(&self) -> &str {
+        self.compression_type.as_str()
+    }
+}
+
+#[cfg(feature = "compression")]
+fn compression_from_options(
+    options: &HashMap<String, String>,
+    next: Option<Box<dyn Externalizer>>,
+) -> CompressionExternalizer {
+    let ct = options
+        .get("compression_type")
+        .and_then(|s| s.parse::<CompressionType>().ok())
+        .unwrap_or_default();
+    let level = options
+        .get("level")
+        .and_then(|s| s.parse::<u32>().ok())
+        .map(|l| flate2::Compression::new(l.clamp(0, 9)))
+        .unwrap_or_default();
+    CompressionExternalizer {
+        compression_type: ct,
+        level,
+        next,
+    }
+}
 
 #[cfg(feature = "compression")]
 fn compress(bytes: &[u8], level: flate2::Compression, ct: &CompressionType) -> CalResult<Vec<u8>> {
@@ -428,37 +456,131 @@ fn decompress(bytes: &[u8], ct: &CompressionType) -> CalResult<Vec<u8>> {
     }
 }
 
-#[cfg(feature = "compression")]
-fn level_from_options(
-    options: &std::collections::HashMap<String, toml::Value>,
-) -> flate2::Compression {
-    options
-        .get("level")
-        .and_then(|v| v.as_integer())
-        .map(|l| flate2::Compression::new(l.clamp(0, 9) as u32))
-        .unwrap_or_default()
-}
-
-#[cfg(feature = "compression")]
-fn make_codec(ct: CompressionType, level: flate2::Compression) -> (ByteTransform, ByteTransform) {
-    let ct2 = ct.clone();
-    let encoder: ByteTransform = Box::new(move |b| compress(b, level, &ct));
-    let decoder: ByteTransform = Box::new(move |b| decompress(b, &ct2));
-    (encoder, decoder)
-}
-
-/// Wrap `inner` in a gzip [`ChainExternalizer`] with default compression level.
-///
-/// For custom compression type or level, use [`build_externalizer`] with a
-/// `[externalizer.<name>]` config section.
+/// Wrap `next` in a gzip [`CompressionExternalizer`] with default compression level.
 ///
 /// Requires the `compression` feature.
 #[cfg(feature = "compression")]
-pub fn new_gzip_externalizer<M: CalMessage>(
-    inner: Box<dyn Externalizer<M>>,
-) -> CompressionExternalizer<M> {
-    let (enc, dec) = make_codec(CompressionType::Gzip, flate2::Compression::default());
-    ChainExternalizer::new(inner, enc, dec)
+pub fn new_gzip_externalizer(next: Box<dyn Externalizer>) -> CompressionExternalizer {
+    CompressionExternalizer::new(
+        Some(next),
+        CompressionType::Gzip,
+        flate2::Compression::default(),
+    )
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// ExternalizerBuilder
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Fluent builder for constructing [`Externalizer`] chains.
+///
+/// # Example
+/// ```text
+/// let ext = builder("xml")
+///     .kind("xml")
+///     .chain("gzip")
+///     .kind("compression")
+///     .option("level", 6)
+///     .build();
+/// ```
+///
+/// The chain above produces `CompressionExternalizer { next: XmlExternalizer }`.
+/// `chain()` wraps the current builder in a new outer builder; the outermost node
+/// is the chain head (applied first during encode).
+pub struct ExternalizerBuilder {
+    name: String,
+    kind: Option<String>,
+    options: HashMap<String, String>,
+    next: Option<Box<ExternalizerBuilder>>,
+}
+
+impl Default for ExternalizerBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExternalizerBuilder {
+    /// Create a builder with no name (useful for testing).
+    pub fn new() -> Self {
+        Self {
+            name: String::new(),
+            kind: None,
+            options: HashMap::new(),
+            next: None,
+        }
+    }
+
+    /// Set the externalizer type (e.g. `"xml"`, `"compression"`).
+    pub fn kind(mut self, kind: &str) -> Self {
+        self.kind = Some(kind.to_string());
+        self
+    }
+
+    /// Set a typed option (stored via `ToString`).
+    pub fn option<T: ToString>(mut self, key: &str, value: T) -> Self {
+        self.options.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    /// Wrap `self` in a new outer externalizer named `outer_name`.
+    ///
+    /// Subsequent [`kind`][Self::kind] and [`option`][Self::option] calls configure
+    /// the outer node. Call [`build`][Self::build] on the returned builder to
+    /// assemble the full chain.
+    pub fn chain(self, outer_name: &str) -> Self {
+        ExternalizerBuilder {
+            name: outer_name.to_string(),
+            kind: None,
+            options: HashMap::new(),
+            next: Some(Box::new(self)),
+        }
+    }
+
+    /// Build the externalizer chain.
+    pub fn build(self) -> CalResult<Box<dyn Externalizer>> {
+        let ExternalizerBuilder {
+            name,
+            kind,
+            options,
+            next,
+        } = self;
+        let effective_kind = kind.as_deref().unwrap_or(&name).to_string();
+        match next {
+            None => match effective_kind.as_str() {
+                "xml" => Ok(Box::new(xml_from_options(&options))),
+                other => Err(CalError::new(
+                    CalErrorKind::SerializationError,
+                    format!("unknown leaf externalizer type: '{other}'"),
+                )),
+            },
+            Some(inner_b) => {
+                #[cfg(feature = "compression")]
+                if effective_kind == "compression" {
+                    let inner_ext = inner_b.build()?;
+                    return Ok(Box::new(compression_from_options(
+                        &options,
+                        Some(inner_ext),
+                    )));
+                }
+                drop(inner_b);
+                Err(CalError::new(
+                    CalErrorKind::SerializationError,
+                    format!("unknown chain externalizer type: '{effective_kind}'"),
+                ))
+            }
+        }
+    }
+}
+
+/// Create a new [`ExternalizerBuilder`] with the given descriptive name.
+pub fn builder(name: impl Into<String>) -> ExternalizerBuilder {
+    ExternalizerBuilder {
+        name: name.into(),
+        kind: None,
+        options: HashMap::new(),
+        next: None,
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -468,35 +590,21 @@ pub fn new_gzip_externalizer<M: CalMessage>(
 /// Build an [`Externalizer`] by name from [`CalConfig`].
 ///
 /// Lookup order:
-/// 1. If `name` appears in `config.externalizer`, use that section's settings.
+/// 1. If `name` appears in `config.externalizer`, use that section.
 /// 2. Otherwise fall back to built-in defaults:
 ///    - `"xml"` → [`XmlExternalizer`] (compact)
-///    - `"compression"` → gzip-wrapped `"xml"` (requires `compression` feature)
-///
-/// The `root` argument sets the XML root element name (typically the topic name).
-pub fn build_externalizer<M>(
-    name: &str,
-    config: &CalConfig,
-    root: impl Into<String>,
-) -> CalResult<Box<dyn Externalizer<M>>>
-where
-    M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
-{
-    let root = root.into();
+///    - `"compression"` / `"gzip"` → gzip-wrapped `"xml"` (requires `compression` feature)
+pub fn build_externalizer(name: &str, config: &CalConfig) -> CalResult<Box<dyn Externalizer>> {
     match config.externalizer.get(name) {
-        Some(ext_cfg) => build_from_config(ext_cfg, config, root),
-        None => build_builtin(name, config, root),
+        Some(ext_cfg) => build_from_config(ext_cfg, config),
+        None => build_builtin(name),
     }
 }
 
-fn build_from_config<M>(
+fn build_from_config(
     ext_cfg: &ExternalizerConfig,
     _config: &CalConfig,
-    root: String,
-) -> CalResult<Box<dyn Externalizer<M>>>
-where
-    M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
-{
+) -> CalResult<Box<dyn Externalizer>> {
     match ext_cfg {
         ExternalizerConfig::Xml { pretty } => {
             let format = if *pretty {
@@ -504,7 +612,7 @@ where
             } else {
                 SerializationFormat::Xml
             };
-            Ok(Box::new(XmlExternalizer::new(format, root)))
+            Ok(Box::new(XmlExternalizer { format, next: None }))
         }
         #[cfg(feature = "compression")]
         ExternalizerConfig::Compression {
@@ -512,31 +620,35 @@ where
             compression_type,
             options,
         } => {
-            let level = level_from_options(options);
-            let inner_ext = build_externalizer::<M>(inner, _config, root)?;
-            let (enc, dec) = make_codec(compression_type.clone(), level);
-            Ok(Box::new(ChainExternalizer::new(inner_ext, enc, dec)))
+            let inner_ext = build_externalizer(inner, _config)?;
+            let level = options
+                .get("level")
+                .and_then(|v| v.as_integer())
+                .map(|l| flate2::Compression::new(l.clamp(0, 9) as u32))
+                .unwrap_or_default();
+            Ok(Box::new(CompressionExternalizer {
+                compression_type: compression_type.clone(),
+                level,
+                next: Some(inner_ext),
+            }))
         }
     }
 }
 
-fn build_builtin<M>(
-    name: &str,
-    _config: &CalConfig,
-    root: String,
-) -> CalResult<Box<dyn Externalizer<M>>>
-where
-    M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
-{
+fn build_builtin(name: &str) -> CalResult<Box<dyn Externalizer>> {
     match name {
-        "xml" => Ok(Box::new(XmlExternalizer::new(
-            SerializationFormat::Xml,
-            root,
-        ))),
+        "xml" => Ok(Box::new(XmlExternalizer {
+            format: SerializationFormat::Xml,
+            next: None,
+        })),
         #[cfg(feature = "compression")]
-        "compression" => {
-            let inner: Box<dyn Externalizer<M>> = build_builtin("xml", _config, root)?;
-            Ok(Box::new(new_gzip_externalizer(inner)))
+        "compression" | "gzip" => {
+            let xml = build_builtin("xml")?;
+            Ok(Box::new(CompressionExternalizer {
+                compression_type: CompressionType::Gzip,
+                level: flate2::Compression::default(),
+                next: Some(xml),
+            }))
         }
         other => Err(CalError::new(
             CalErrorKind::SerializationError,
@@ -551,33 +663,23 @@ where
 
 /// [`ExternalizerLoader`] that produces [`XmlExternalizer`] instances.
 ///
-/// Supports `"xml"` encoding (and `"xml+gzip"` with the `compression` feature).
+/// Supports `"xml"` encoding.
 /// Returns [`CalErrorKind::SerializationError`] for unrecognised encoding strings.
 #[derive(Default)]
 pub struct XmlExternalizerLoader;
 
-impl<M> ExternalizerLoader<M> for XmlExternalizerLoader
-where
-    M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
-{
+impl ExternalizerLoader for XmlExternalizerLoader {
     fn get_externalizer(
         &self,
         encoding: &str,
         _schema_version: &str,
         _vendor_version: &str,
-    ) -> CalResult<Box<dyn Externalizer<M>>> {
+    ) -> CalResult<Box<dyn Externalizer>> {
         match encoding {
-            XML_EXTERNALIZER_ENCODING => Ok(Box::new(XmlExternalizer::new(
-                SerializationFormat::default(),
-                M::message_type_name().local().to_string(),
-            ))),
-            #[cfg(feature = "compression")]
-            XML_GZIP_EXTERNALIZER_ENCODING => Ok(Box::new(new_gzip_externalizer(Box::new(
-                XmlExternalizer::new(
-                    SerializationFormat::default(),
-                    M::message_type_name().local().to_string(),
-                ),
-            )))),
+            XML_EXTERNALIZER_ENCODING => Ok(Box::new(XmlExternalizer {
+                format: SerializationFormat::default(),
+                next: None,
+            })),
             other => Err(CalError::new(
                 CalErrorKind::SerializationError,
                 format!("unsupported externalizer encoding: '{other}'"),
@@ -593,7 +695,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    /// Minimal CalMessage stub for externalizer round-trip tests.
+
     #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
     struct TestMsg {
         value: i32,
@@ -608,38 +710,39 @@ mod tests {
         }
     }
 
+    const ROOT: &str = "TestMsg";
+
     #[test]
-    fn xml_externalizer_round_trip_str() {
-        let ext = XmlExternalizer::new(SerializationFormat::Xml, "TestMsg");
+    fn xml_round_trip_str() {
+        let ext = XmlExternalizer::new(SerializationFormat::Xml);
         let msg = TestMsg { value: 42 };
-        let s = ext.write_to_string(&msg).unwrap();
-        let decoded: TestMsg = ext.read_from_str(&s).unwrap();
+        let s = write_to_string(&ext, &msg, ROOT).unwrap();
+        let decoded: TestMsg = read_from_str(&ext, &s).unwrap();
         assert_eq!(decoded, msg);
     }
 
     #[test]
-    fn xml_externalizer_round_trip_bytes() {
-        let ext = XmlExternalizer::new(SerializationFormat::Xml, "TestMsg");
+    fn xml_round_trip_bytes() {
+        let ext = XmlExternalizer::new(SerializationFormat::Xml);
         let msg = TestMsg { value: 7 };
-        let bytes = ext.write_to_bytes(&msg).unwrap();
-        let decoded: TestMsg = ext.read_from_bytes(&bytes).unwrap();
+        let bytes = write_to_bytes(&ext, &msg, ROOT).unwrap();
+        let decoded: TestMsg = read_from_bytes(&ext, &bytes).unwrap();
         assert_eq!(decoded, msg);
     }
 
     #[test]
-    fn xml_externalizer_round_trip_reader_writer() {
-        let ext = XmlExternalizer::new(SerializationFormat::Xml, "TestMsg");
+    fn xml_round_trip_reader_writer() {
+        let ext = XmlExternalizer::new(SerializationFormat::Xml);
         let msg = TestMsg { value: 99 };
         let mut buf = Vec::new();
-        ext.write_to_writer(&msg, &mut buf).unwrap();
-        let decoded: TestMsg = ext.read_from_reader(&mut buf.as_slice()).unwrap();
+        write_to_writer(&ext, &msg, ROOT, &mut buf).unwrap();
+        let decoded: TestMsg = read_from_reader(&ext, &mut buf.as_slice()).unwrap();
         assert_eq!(decoded, msg);
     }
 
     #[test]
     fn xml_externalizer_identity() {
-        let ext: Box<dyn Externalizer<TestMsg>> =
-            Box::new(XmlExternalizer::new(SerializationFormat::Xml, "TestMsg"));
+        let ext: Box<dyn Externalizer> = Box::new(XmlExternalizer::new(SerializationFormat::Xml));
         assert_eq!(ext.get_encoding(), "xml");
         assert_eq!(ext.get_cal_api_version(), "2.5");
         assert_eq!(ext.get_vendor(), "rcal");
@@ -650,35 +753,46 @@ mod tests {
     }
 
     #[test]
-    fn xml_externalizer_loader_ok() {
-        let loader: XmlExternalizerLoader = Default::default();
-        let ext: Box<dyn Externalizer<TestMsg>> =
-            loader.get_externalizer("xml", "2.5", "1.0").unwrap();
+    fn loader_ok() {
+        let loader = XmlExternalizerLoader::default();
+        let ext = loader.get_externalizer("xml", "2.5", "1.0").unwrap();
         assert_eq!(ext.get_encoding(), "xml");
     }
 
     #[test]
-    fn chain_externalizer_round_trip() {
-        // trivial rot-0 "transform" (identity) to verify the chain plumbing
-        let inner: Box<dyn Externalizer<TestMsg>> =
-            Box::new(XmlExternalizer::new(SerializationFormat::Xml, "TestMsg"));
-        let chain = ChainExternalizer::new(
-            inner,
-            |b| Ok(b.iter().map(|x| x.wrapping_add(1)).collect()),
-            |b| Ok(b.iter().map(|x| x.wrapping_sub(1)).collect()),
+    fn loader_unknown_encoding() {
+        let loader = XmlExternalizerLoader::default();
+        let result = loader.get_externalizer("binary", "2.5", "1.0");
+        assert_eq!(
+            result.err().unwrap().kind(),
+            &CalErrorKind::SerializationError
         );
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn compression_round_trip() {
+        let xml: Box<dyn Externalizer> = Box::new(XmlExternalizer::new(SerializationFormat::Xml));
+        let gzip = new_gzip_externalizer(xml);
         let msg = TestMsg { value: 55 };
-        let bytes = chain.write_to_bytes(&msg).unwrap();
-        let decoded: TestMsg = chain.read_from_bytes(&bytes).unwrap();
+        let compressed = write_to_bytes(&gzip, &msg, ROOT).unwrap();
+        let decoded: TestMsg = read_from_bytes(&gzip, &compressed).unwrap();
         assert_eq!(decoded, msg);
     }
 
+    #[cfg(feature = "compression")]
     #[test]
-    fn xml_externalizer_loader_unknown_encoding() {
-        let loader: XmlExternalizerLoader = Default::default();
-        let result: CalResult<Box<dyn Externalizer<TestMsg>>> =
-            loader.get_externalizer("binary", "2.5", "1.0");
-        let err = result.err().expect("expected error");
-        assert_eq!(err.kind(), &CalErrorKind::SerializationError);
+    fn builder_xml_gzip() {
+        let ext = builder("xml")
+            .kind("xml")
+            .chain("gzip")
+            .kind("compression")
+            .build()
+            .unwrap();
+        let msg = TestMsg { value: 99 };
+        let compressed = write_to_bytes(ext.as_ref(), &msg, ROOT).unwrap();
+        let decoded: TestMsg = read_from_bytes(ext.as_ref(), &compressed).unwrap();
+        assert_eq!(decoded, msg);
+        assert_eq!(ext.get_encoding(), "gzip");
     }
 }

--- a/rcal/src/externalizer.rs
+++ b/rcal/src/externalizer.rs
@@ -1,0 +1,365 @@
+//! Abstract Externalizer / ExternalizerLoader interfaces plus XML implementation.
+//!
+//! ## Specification references
+//! - OMSC-SPC-008 Rev K §9.13–9.15 (CXX-012071–012446)
+
+#![warn(missing_docs)]
+
+use crate::calconfig::SerializationFormat;
+use crate::uci::{CalError, CalErrorKind, CalMessage, CalResult};
+use std::io::{Read, Write};
+
+// ════════════════════════════════════════════════════════════════════════════
+// Externalizer<M>
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Abstract serialization/deserialization interface for a single CAL Message type.
+///
+/// Rust equivalent of `uci::base::Externalizer` (OMSC-SPC-008 §9.13).
+/// The trait is generic over `M: CalMessage` so that `dyn Externalizer<M>` is
+/// a valid trait object for any specific message type `M`.
+///
+/// Obtain instances from an [`ExternalizerLoader`] or construct them directly
+/// (e.g. [`XmlExternalizer`]).
+///
+/// # CERT coverage
+/// CXX-012071, CXX-012099, CXX-012115, CXX-012131, CXX-012146, CXX-012161,
+/// CXX-012176, CXX-012238, CXX-012252, CXX-012266, CXX-012280, CXX-012294,
+/// CXX-012688, CXX-012689, CXX-012690, CXX-012691
+pub trait Externalizer<M: CalMessage>: Send + Sync {
+    // ── Read (CXX-012099, 012115, 012131) ───────────────────────────────────
+
+    /// Deserialize a message by reading from `reader` (CXX-012099).
+    fn read_from_reader(&self, reader: &mut dyn Read) -> CalResult<M>;
+
+    /// Deserialize a message from a UTF-8 string (CXX-012115).
+    fn read_from_str(&self, s: &str) -> CalResult<M>;
+
+    /// Deserialize a message from a byte slice (CXX-012131).
+    fn read_from_bytes(&self, bytes: &[u8]) -> CalResult<M>;
+
+    // ── Write (CXX-012146, 012161, 012176) ──────────────────────────────────
+
+    /// Serialize `msg` and write the bytes to `writer` (CXX-012146).
+    fn write_to_writer(&self, msg: &M, writer: &mut dyn Write) -> CalResult<()>;
+
+    /// Serialize `msg` to a [`String`] (CXX-012161).
+    fn write_to_string(&self, msg: &M) -> CalResult<String>;
+
+    /// Serialize `msg` to a byte vector (CXX-012176).
+    fn write_to_bytes(&self, msg: &M) -> CalResult<Vec<u8>>;
+
+    // ── Version / identity (CXX-012238, 012252, 012266, 012280, 012294) ─────
+
+    /// Returns the CAL API version string (CXX-012238).
+    fn get_cal_api_version(&self) -> &str;
+
+    /// Returns the encoding identifier, e.g. `"xml"` (CXX-012252).
+    fn get_encoding(&self) -> &str;
+
+    /// Returns the UCI schema version this externalizer targets (CXX-012266).
+    fn get_schema_version(&self) -> &str;
+
+    /// Returns the vendor-specific version string (CXX-012280).
+    fn get_vendor_version(&self) -> &str;
+
+    /// Returns the vendor name (CXX-012294).
+    fn get_vendor(&self) -> &str;
+
+    // ── Capability queries (CXX-012688–012691) ───────────────────────────────
+
+    /// Returns `true` if this externalizer supports read operations only (CXX-012688).
+    fn message_read_only(&self) -> bool;
+
+    /// Returns `true` if this externalizer supports write operations only (CXX-012689).
+    fn message_write_only(&self) -> bool;
+
+    /// Returns `true` if read operations are supported (CXX-012690).
+    fn supports_object_read(&self) -> bool;
+
+    /// Returns `true` if write operations are supported (CXX-012691).
+    fn supports_object_write(&self) -> bool;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// ExternalizerLoader<M>
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Factory for obtaining [`Externalizer`] instances by encoding name.
+///
+/// Rust equivalent of `uci::base::ExternalizerLoader` (OMSC-SPC-008 §9.14).
+/// `destroy_externalizer` (CXX-012381) is unnecessary in Rust — `Box` drop
+/// handles deallocation.
+///
+/// # CERT coverage
+/// CXX-012338, CXX-012367, CXX-012381
+pub trait ExternalizerLoader<M: CalMessage>: Send + Sync {
+    /// Return a boxed [`Externalizer`] for the requested encoding.
+    ///
+    /// `encoding` — format identifier, e.g. `"xml"`.
+    /// `schema_version` — target UCI schema version.
+    /// `vendor_version` — implementor-defined version string.
+    ///
+    /// Returns [`CalErrorKind::SerializationError`] if the encoding is not
+    /// supported by this loader (CXX-012367).
+    fn get_externalizer(
+        &self,
+        encoding: &str,
+        schema_version: &str,
+        vendor_version: &str,
+    ) -> CalResult<Box<dyn Externalizer<M>>>;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Global free functions (CXX-012434, CXX-012446)
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Return the default [`ExternalizerLoader`] for message type `M` (CXX-012434).
+///
+/// The default loader supports `"xml"` encoding via [`XmlExternalizerLoader`].
+pub fn get_externalizer_loader<M: CalMessage + serde::Serialize + serde::de::DeserializeOwned>()
+-> Box<dyn ExternalizerLoader<M>> {
+    Box::new(XmlExternalizerLoader)
+}
+
+/// Destroy an [`ExternalizerLoader`] obtained via [`get_externalizer_loader`] (CXX-012446).
+///
+/// In Rust, this is a no-op — ownership passed into the `Box` is dropped when
+/// it goes out of scope. This function exists purely for specification alignment.
+pub fn destroy_externalizer_loader<M: CalMessage>(_loader: Box<dyn ExternalizerLoader<M>>) {}
+
+// ════════════════════════════════════════════════════════════════════════════
+// XmlExternalizer
+// ════════════════════════════════════════════════════════════════════════════
+
+/// CAL API version string reported by the XML externalizer.
+pub const XML_EXTERNALIZER_CAL_API_VERSION: &str = "2.5";
+/// Encoding identifier for the XML externalizer.
+pub const XML_EXTERNALIZER_ENCODING: &str = "xml";
+/// Vendor name for this implementation.
+pub const XML_EXTERNALIZER_VENDOR: &str = "rcal";
+
+/// XML-based [`Externalizer`] backed by `quick_xml` / `serde`.
+///
+/// Implements [`Externalizer<M>`] for all `M: CalMessage + serde::Serialize +
+/// serde::de::DeserializeOwned`. The `root` field sets the XML root element
+/// name written by [`write_to_string`][XmlExternalizer::write_to_string];
+/// callers such as [`ZmqWriter`][crate::asb::zmq::ZmqWriter] pass the topic
+/// name here.
+pub struct XmlExternalizer {
+    format: SerializationFormat,
+    root: String,
+}
+
+impl XmlExternalizer {
+    /// Construct a new `XmlExternalizer` with the given format and root element name.
+    pub fn new(format: SerializationFormat, root: impl Into<String>) -> Self {
+        Self {
+            format,
+            root: root.into(),
+        }
+    }
+}
+
+impl<M> Externalizer<M> for XmlExternalizer
+where
+    M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
+{
+    fn read_from_reader(&self, reader: &mut dyn Read) -> CalResult<M> {
+        let mut buf = Vec::new();
+        reader
+            .read_to_end(&mut buf)
+            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
+        self.read_from_bytes(&buf)
+    }
+
+    fn read_from_str(&self, s: &str) -> CalResult<M> {
+        quick_xml::de::from_str(s)
+            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
+    }
+
+    fn read_from_bytes(&self, bytes: &[u8]) -> CalResult<M> {
+        let s = std::str::from_utf8(bytes)
+            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
+        self.read_from_str(s)
+    }
+
+    fn write_to_writer(&self, msg: &M, writer: &mut dyn Write) -> CalResult<()> {
+        let s = self.write_to_string(msg)?;
+        writer
+            .write_all(s.as_bytes())
+            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
+    }
+
+    fn write_to_string(&self, msg: &M) -> CalResult<String> {
+        match self.format {
+            SerializationFormat::Xml => quick_xml::se::to_string_with_root(&self.root, msg)
+                .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string())),
+            SerializationFormat::PrettyXml => {
+                let mut buf = String::new();
+                let mut ser = quick_xml::se::Serializer::with_root(&mut buf, Some(&self.root))
+                    .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
+                ser.indent(' ', 4);
+                serde::Serialize::serialize(msg, ser)
+                    .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
+                Ok(buf)
+            }
+        }
+    }
+
+    fn write_to_bytes(&self, msg: &M) -> CalResult<Vec<u8>> {
+        self.write_to_string(msg).map(String::into_bytes)
+    }
+
+    fn get_cal_api_version(&self) -> &str {
+        XML_EXTERNALIZER_CAL_API_VERSION
+    }
+
+    fn get_encoding(&self) -> &str {
+        XML_EXTERNALIZER_ENCODING
+    }
+
+    fn get_schema_version(&self) -> &str {
+        // ponytail: returns crate version; replace with schema version constant when defined
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn get_vendor_version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn get_vendor(&self) -> &str {
+        XML_EXTERNALIZER_VENDOR
+    }
+
+    fn message_read_only(&self) -> bool {
+        false
+    }
+
+    fn message_write_only(&self) -> bool {
+        false
+    }
+
+    fn supports_object_read(&self) -> bool {
+        true
+    }
+
+    fn supports_object_write(&self) -> bool {
+        true
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// XmlExternalizerLoader
+// ════════════════════════════════════════════════════════════════════════════
+
+/// [`ExternalizerLoader`] that produces [`XmlExternalizer`] instances.
+///
+/// Supports `"xml"` encoding only. Returns [`CalErrorKind::SerializationError`]
+/// for unrecognised encoding strings.
+#[derive(Default)]
+pub struct XmlExternalizerLoader;
+
+impl<M> ExternalizerLoader<M> for XmlExternalizerLoader
+where
+    M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
+{
+    fn get_externalizer(
+        &self,
+        encoding: &str,
+        _schema_version: &str,
+        _vendor_version: &str,
+    ) -> CalResult<Box<dyn Externalizer<M>>> {
+        match encoding {
+            XML_EXTERNALIZER_ENCODING => Ok(Box::new(XmlExternalizer::new(
+                SerializationFormat::default(),
+                M::message_type_name().local().to_string(),
+            ))),
+            other => Err(CalError::new(
+                CalErrorKind::SerializationError,
+                format!("unsupported externalizer encoding: '{other}'"),
+            )),
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Tests
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    /// Minimal CalMessage stub for externalizer round-trip tests.
+    #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+    struct TestMsg {
+        value: i32,
+    }
+
+    impl CalMessage for TestMsg {
+        fn message_type_name() -> crate::QName {
+            crate::QName::new(None, "TestMsg")
+        }
+        fn cal_create() -> Self {
+            TestMsg { value: 0 }
+        }
+    }
+
+    #[test]
+    fn xml_externalizer_round_trip_str() {
+        let ext = XmlExternalizer::new(SerializationFormat::Xml, "TestMsg");
+        let msg = TestMsg { value: 42 };
+        let s = ext.write_to_string(&msg).unwrap();
+        let decoded: TestMsg = ext.read_from_str(&s).unwrap();
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn xml_externalizer_round_trip_bytes() {
+        let ext = XmlExternalizer::new(SerializationFormat::Xml, "TestMsg");
+        let msg = TestMsg { value: 7 };
+        let bytes = ext.write_to_bytes(&msg).unwrap();
+        let decoded: TestMsg = ext.read_from_bytes(&bytes).unwrap();
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn xml_externalizer_round_trip_reader_writer() {
+        let ext = XmlExternalizer::new(SerializationFormat::Xml, "TestMsg");
+        let msg = TestMsg { value: 99 };
+        let mut buf = Vec::new();
+        ext.write_to_writer(&msg, &mut buf).unwrap();
+        let decoded: TestMsg = ext.read_from_reader(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn xml_externalizer_identity() {
+        let ext: Box<dyn Externalizer<TestMsg>> =
+            Box::new(XmlExternalizer::new(SerializationFormat::Xml, "TestMsg"));
+        assert_eq!(ext.get_encoding(), "xml");
+        assert_eq!(ext.get_cal_api_version(), "2.5");
+        assert_eq!(ext.get_vendor(), "rcal");
+        assert!(!ext.message_read_only());
+        assert!(!ext.message_write_only());
+        assert!(ext.supports_object_read());
+        assert!(ext.supports_object_write());
+    }
+
+    #[test]
+    fn xml_externalizer_loader_ok() {
+        let loader: XmlExternalizerLoader = Default::default();
+        let ext: Box<dyn Externalizer<TestMsg>> =
+            loader.get_externalizer("xml", "2.5", "1.0").unwrap();
+        assert_eq!(ext.get_encoding(), "xml");
+    }
+
+    #[test]
+    fn xml_externalizer_loader_unknown_encoding() {
+        let loader: XmlExternalizerLoader = Default::default();
+        let result: CalResult<Box<dyn Externalizer<TestMsg>>> =
+            loader.get_externalizer("binary", "2.5", "1.0");
+        let err = result.err().expect("expected error");
+        assert_eq!(err.kind(), &CalErrorKind::SerializationError);
+    }
+}

--- a/rcal/src/externalizer.rs
+++ b/rcal/src/externalizer.rs
@@ -5,7 +5,9 @@
 
 #![warn(missing_docs)]
 
-use crate::calconfig::SerializationFormat;
+#[cfg(feature = "compression")]
+use crate::calconfig::CompressionType;
+use crate::calconfig::{CalConfig, ExternalizerConfig, SerializationFormat};
 use crate::uci::{CalError, CalErrorKind, CalMessage, CalResult};
 use std::io::{Read, Write};
 
@@ -247,13 +249,310 @@ where
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+// ChainExternalizer<M>
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Byte transform function used by [`ChainExternalizer`].
+type ByteTransform = Box<dyn Fn(&[u8]) -> CalResult<Vec<u8>> + Send + Sync>;
+
+/// Byte-level pipeline wrapper around an [`Externalizer`].
+///
+/// Applies `encode` to serialized bytes before writing, and `decode` to raw
+/// bytes before deserializing. Use this to add compression, encryption, or any
+/// other byte transform without changing the inner externalizer.
+///
+/// **Implicit chaining** is also available: pass a wrapping `impl Write`
+/// (e.g. a gzip encoder) to [`write_to_writer`][Externalizer::write_to_writer]
+/// and a wrapping `impl Read` to [`read_from_reader`][Externalizer::read_from_reader]
+/// directly — no `ChainExternalizer` needed.
+///
+/// # Example (conceptual)
+/// ```text
+/// let chain = ChainExternalizer::new(
+///     Box::new(XmlExternalizer::new(SerializationFormat::Xml, "Msg")),
+///     |bytes| gzip_compress(bytes),
+///     |bytes| gzip_decompress(bytes),
+/// );
+/// // write path: XML → gzip bytes
+/// // read path:  gzip bytes → XML → M
+/// ```
+pub struct ChainExternalizer<M: CalMessage> {
+    inner: Box<dyn Externalizer<M>>,
+    encode: ByteTransform,
+    decode: ByteTransform,
+}
+
+impl<M: CalMessage> ChainExternalizer<M> {
+    /// Construct a chained externalizer.
+    ///
+    /// `encode` transforms bytes *after* serialization (e.g. compress/encrypt).
+    /// `decode` transforms bytes *before* deserialization (e.g. decompress/decrypt).
+    pub fn new(
+        inner: Box<dyn Externalizer<M>>,
+        encode: impl Fn(&[u8]) -> CalResult<Vec<u8>> + Send + Sync + 'static,
+        decode: impl Fn(&[u8]) -> CalResult<Vec<u8>> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            inner,
+            encode: Box::new(encode),
+            decode: Box::new(decode),
+        }
+    }
+}
+
+impl<M: CalMessage> Externalizer<M> for ChainExternalizer<M> {
+    fn read_from_reader(&self, reader: &mut dyn Read) -> CalResult<M> {
+        let mut buf = Vec::new();
+        reader
+            .read_to_end(&mut buf)
+            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
+        self.read_from_bytes(&buf)
+    }
+
+    fn read_from_str(&self, s: &str) -> CalResult<M> {
+        self.read_from_bytes(s.as_bytes())
+    }
+
+    fn read_from_bytes(&self, bytes: &[u8]) -> CalResult<M> {
+        let decoded = (self.decode)(bytes)?;
+        self.inner.read_from_bytes(&decoded)
+    }
+
+    fn write_to_writer(&self, msg: &M, writer: &mut dyn Write) -> CalResult<()> {
+        let encoded = self.write_to_bytes(msg)?;
+        writer
+            .write_all(&encoded)
+            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
+    }
+
+    fn write_to_string(&self, msg: &M) -> CalResult<String> {
+        let bytes = self.write_to_bytes(msg)?;
+        String::from_utf8(bytes)
+            .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
+    }
+
+    fn write_to_bytes(&self, msg: &M) -> CalResult<Vec<u8>> {
+        let raw = self.inner.write_to_bytes(msg)?;
+        (self.encode)(&raw)
+    }
+
+    fn get_cal_api_version(&self) -> &str {
+        self.inner.get_cal_api_version()
+    }
+
+    fn get_encoding(&self) -> &str {
+        self.inner.get_encoding()
+    }
+
+    fn get_schema_version(&self) -> &str {
+        self.inner.get_schema_version()
+    }
+
+    fn get_vendor_version(&self) -> &str {
+        self.inner.get_vendor_version()
+    }
+
+    fn get_vendor(&self) -> &str {
+        self.inner.get_vendor()
+    }
+
+    fn message_read_only(&self) -> bool {
+        self.inner.message_read_only()
+    }
+
+    fn message_write_only(&self) -> bool {
+        self.inner.message_write_only()
+    }
+
+    fn supports_object_read(&self) -> bool {
+        self.inner.supports_object_read()
+    }
+
+    fn supports_object_write(&self) -> bool {
+        self.inner.supports_object_write()
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// CompressionExternalizer (feature = "compression")
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A [`ChainExternalizer`] pre-configured with a compression codec.
+///
+/// Construct with [`new_gzip_externalizer`] or via [`build_externalizer`] with
+/// a `[externalizer.<name>]` section of `type = "compression"` in config.
+///
+/// Requires the `compression` feature.
+#[cfg(feature = "compression")]
+pub type CompressionExternalizer<M> = ChainExternalizer<M>;
+
+/// Encoding identifier for XML + gzip (used by [`XmlExternalizerLoader`]).
+#[cfg(feature = "compression")]
+pub const XML_GZIP_EXTERNALIZER_ENCODING: &str = "xml+gzip";
+
+#[cfg(feature = "compression")]
+fn compress(bytes: &[u8], level: flate2::Compression, ct: &CompressionType) -> CalResult<Vec<u8>> {
+    use flate2::write::{DeflateEncoder, GzEncoder, ZlibEncoder};
+    macro_rules! enc {
+        ($T:ident) => {{
+            let mut e = $T::new(Vec::new(), level);
+            e.write_all(bytes)
+                .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
+            e.finish()
+                .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))
+        }};
+    }
+    match ct {
+        CompressionType::Gzip => enc!(GzEncoder),
+        CompressionType::Deflate => enc!(DeflateEncoder),
+        CompressionType::Zlib => enc!(ZlibEncoder),
+    }
+}
+
+#[cfg(feature = "compression")]
+fn decompress(bytes: &[u8], ct: &CompressionType) -> CalResult<Vec<u8>> {
+    use flate2::read::{DeflateDecoder, GzDecoder, ZlibDecoder};
+    macro_rules! dec {
+        ($T:ident) => {{
+            let mut d = $T::new(bytes);
+            let mut out = Vec::new();
+            d.read_to_end(&mut out)
+                .map_err(|e| CalError::new(CalErrorKind::SerializationError, e.to_string()))?;
+            Ok(out)
+        }};
+    }
+    match ct {
+        CompressionType::Gzip => dec!(GzDecoder),
+        CompressionType::Deflate => dec!(DeflateDecoder),
+        CompressionType::Zlib => dec!(ZlibDecoder),
+    }
+}
+
+#[cfg(feature = "compression")]
+fn level_from_options(
+    options: &std::collections::HashMap<String, toml::Value>,
+) -> flate2::Compression {
+    options
+        .get("level")
+        .and_then(|v| v.as_integer())
+        .map(|l| flate2::Compression::new(l.clamp(0, 9) as u32))
+        .unwrap_or_default()
+}
+
+#[cfg(feature = "compression")]
+fn make_codec(ct: CompressionType, level: flate2::Compression) -> (ByteTransform, ByteTransform) {
+    let ct2 = ct.clone();
+    let encoder: ByteTransform = Box::new(move |b| compress(b, level, &ct));
+    let decoder: ByteTransform = Box::new(move |b| decompress(b, &ct2));
+    (encoder, decoder)
+}
+
+/// Wrap `inner` in a gzip [`ChainExternalizer`] with default compression level.
+///
+/// For custom compression type or level, use [`build_externalizer`] with a
+/// `[externalizer.<name>]` config section.
+///
+/// Requires the `compression` feature.
+#[cfg(feature = "compression")]
+pub fn new_gzip_externalizer<M: CalMessage>(
+    inner: Box<dyn Externalizer<M>>,
+) -> CompressionExternalizer<M> {
+    let (enc, dec) = make_codec(CompressionType::Gzip, flate2::Compression::default());
+    ChainExternalizer::new(inner, enc, dec)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// build_externalizer — config-driven factory
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Build an [`Externalizer`] by name from [`CalConfig`].
+///
+/// Lookup order:
+/// 1. If `name` appears in `config.externalizer`, use that section's settings.
+/// 2. Otherwise fall back to built-in defaults:
+///    - `"xml"` → [`XmlExternalizer`] (compact)
+///    - `"compression"` → gzip-wrapped `"xml"` (requires `compression` feature)
+///
+/// The `root` argument sets the XML root element name (typically the topic name).
+pub fn build_externalizer<M>(
+    name: &str,
+    config: &CalConfig,
+    root: impl Into<String>,
+) -> CalResult<Box<dyn Externalizer<M>>>
+where
+    M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
+{
+    let root = root.into();
+    match config.externalizer.get(name) {
+        Some(ext_cfg) => build_from_config(ext_cfg, config, root),
+        None => build_builtin(name, config, root),
+    }
+}
+
+fn build_from_config<M>(
+    ext_cfg: &ExternalizerConfig,
+    _config: &CalConfig,
+    root: String,
+) -> CalResult<Box<dyn Externalizer<M>>>
+where
+    M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
+{
+    match ext_cfg {
+        ExternalizerConfig::Xml { pretty } => {
+            let format = if *pretty {
+                SerializationFormat::PrettyXml
+            } else {
+                SerializationFormat::Xml
+            };
+            Ok(Box::new(XmlExternalizer::new(format, root)))
+        }
+        #[cfg(feature = "compression")]
+        ExternalizerConfig::Compression {
+            inner,
+            compression_type,
+            options,
+        } => {
+            let level = level_from_options(options);
+            let inner_ext = build_externalizer::<M>(inner, _config, root)?;
+            let (enc, dec) = make_codec(compression_type.clone(), level);
+            Ok(Box::new(ChainExternalizer::new(inner_ext, enc, dec)))
+        }
+    }
+}
+
+fn build_builtin<M>(
+    name: &str,
+    _config: &CalConfig,
+    root: String,
+) -> CalResult<Box<dyn Externalizer<M>>>
+where
+    M: CalMessage + serde::Serialize + serde::de::DeserializeOwned,
+{
+    match name {
+        "xml" => Ok(Box::new(XmlExternalizer::new(
+            SerializationFormat::Xml,
+            root,
+        ))),
+        #[cfg(feature = "compression")]
+        "compression" => {
+            let inner: Box<dyn Externalizer<M>> = build_builtin("xml", _config, root)?;
+            Ok(Box::new(new_gzip_externalizer(inner)))
+        }
+        other => Err(CalError::new(
+            CalErrorKind::SerializationError,
+            format!("unknown externalizer: '{other}'"),
+        )),
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 // XmlExternalizerLoader
 // ════════════════════════════════════════════════════════════════════════════
 
 /// [`ExternalizerLoader`] that produces [`XmlExternalizer`] instances.
 ///
-/// Supports `"xml"` encoding only. Returns [`CalErrorKind::SerializationError`]
-/// for unrecognised encoding strings.
+/// Supports `"xml"` encoding (and `"xml+gzip"` with the `compression` feature).
+/// Returns [`CalErrorKind::SerializationError`] for unrecognised encoding strings.
 #[derive(Default)]
 pub struct XmlExternalizerLoader;
 
@@ -272,6 +571,13 @@ where
                 SerializationFormat::default(),
                 M::message_type_name().local().to_string(),
             ))),
+            #[cfg(feature = "compression")]
+            XML_GZIP_EXTERNALIZER_ENCODING => Ok(Box::new(new_gzip_externalizer(Box::new(
+                XmlExternalizer::new(
+                    SerializationFormat::default(),
+                    M::message_type_name().local().to_string(),
+                ),
+            )))),
             other => Err(CalError::new(
                 CalErrorKind::SerializationError,
                 format!("unsupported externalizer encoding: '{other}'"),
@@ -349,6 +655,22 @@ mod tests {
         let ext: Box<dyn Externalizer<TestMsg>> =
             loader.get_externalizer("xml", "2.5", "1.0").unwrap();
         assert_eq!(ext.get_encoding(), "xml");
+    }
+
+    #[test]
+    fn chain_externalizer_round_trip() {
+        // trivial rot-0 "transform" (identity) to verify the chain plumbing
+        let inner: Box<dyn Externalizer<TestMsg>> =
+            Box::new(XmlExternalizer::new(SerializationFormat::Xml, "TestMsg"));
+        let chain = ChainExternalizer::new(
+            inner,
+            |b| Ok(b.iter().map(|x| x.wrapping_add(1)).collect()),
+            |b| Ok(b.iter().map(|x| x.wrapping_sub(1)).collect()),
+        );
+        let msg = TestMsg { value: 55 };
+        let bytes = chain.write_to_bytes(&msg).unwrap();
+        let decoded: TestMsg = chain.read_from_bytes(&bytes).unwrap();
+        assert_eq!(decoded, msg);
     }
 
     #[test]

--- a/rcal/src/externalizer.rs
+++ b/rcal/src/externalizer.rs
@@ -117,16 +117,13 @@ pub trait ExternalizerLoader<M: CalMessage>: Send + Sync {
 /// Return the default [`ExternalizerLoader`] for message type `M` (CXX-012434).
 ///
 /// The default loader supports `"xml"` encoding via [`XmlExternalizerLoader`].
+/// To release the loader, simply drop the returned `Box` — no explicit destroy
+/// call is needed (contrast with CXX-012446, which is a C++ memory-management
+/// artefact with no Rust equivalent).
 pub fn get_externalizer_loader<M: CalMessage + serde::Serialize + serde::de::DeserializeOwned>()
 -> Box<dyn ExternalizerLoader<M>> {
     Box::new(XmlExternalizerLoader)
 }
-
-/// Destroy an [`ExternalizerLoader`] obtained via [`get_externalizer_loader`] (CXX-012446).
-///
-/// In Rust, this is a no-op — ownership passed into the `Box` is dropped when
-/// it goes out of scope. This function exists purely for specification alignment.
-pub fn destroy_externalizer_loader<M: CalMessage>(_loader: Box<dyn ExternalizerLoader<M>>) {}
 
 // ════════════════════════════════════════════════════════════════════════════
 // XmlExternalizer

--- a/rcal/src/lib.rs
+++ b/rcal/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod asb;
 pub mod cal;
 pub mod calconfig;
+pub mod externalizer;
 pub mod logging;
 pub mod qname;
 #[cfg(feature = "service")]

--- a/rcal/src/uci/base.rs
+++ b/rcal/src/uci/base.rs
@@ -35,6 +35,7 @@ pub use crate::cal::{
     TimeBasedFilter, TopicQos,
 };
 pub use crate::calconfig::SerializationFormat;
+pub use crate::externalizer::{Externalizer, ExternalizerLoader};
 
 /// Re-exported [`uuid::Timestamp`] so callers can build version-1 UUID
 /// timestamps without declaring a direct `uuid` crate dependency.


### PR DESCRIPTION
Closes #54

## Summary

- Implements `uci::base::Externalizer<M>` and `ExternalizerLoader<M>` traits per OMSC-SPC-008 §9.13–9.15 (CERT CXX-012071–012446)
- Adds `XmlExternalizer` / `XmlExternalizerLoader` concrete types backed by `quick_xml` + `serde`
- Refactors `ZmqWriter<M>` / `ZmqReader<M>` to hold `Arc<dyn Externalizer<M>>` instead of hardcoded XML helpers — removes private `serialize_message` / `deserialize_message` free functions
- Exposes `get_externalizer_loader` free function (CXX-012434); `destroy_externalizer_loader` omitted — dropping the `Box` is the Rust idiom
- Updates Archimate design with new interfaces and components

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --no-deps` — clean
- [x] `cargo fmt --all` — applied
- [x] `cargo test --workspace --all-targets` — 64+9 tests pass, no regressions
- [x] Ponytail review — lean; no removable over-engineering
- [x] Caveman review — one finding fixed: `XmlExternalizerLoader` now derives root element name from `M::message_type_name()` instead of empty string (which would produce malformed XML)