### PR TITLE
fix: cleanup batch closes #62 #63 #64 #65 #74 #79

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   clippy:
     name: Run clippy on workspace

--- a/design/oms_rust_cal_core.archimate
+++ b/design/oms_rust_cal_core.archimate
@@ -127,6 +127,25 @@
         <documentation>Enum controlling XML serialization style. Variants: Xml (compact, no whitespace), PrettyXml (indented, human-readable). Configured per transport via the 'format' key in [[transport]] TOML. Default: Xml. Now stored in XmlExternalizer rather than directly in ZmqWriter/ZmqReader.</documentation>
       </element>
     </folder>
+    <folder name="Configuration" id="f-config">
+      <element xsi:type="archimate:DataObject" name="CalConfig" id="e-calconfig">
+        <documentation>Top-level TOML configuration struct (rcal::calconfig). Deserialized at startup. Sections: System (OMS system metadata), UUIDFactory (UUID generation strategy), Vec of Transport (network transport parameters including URI, format, topic whitelist), Vec of Service (per-service transport binding), HashMap of ExternalizerConfig (named serialization overrides). Consumed by get_cal() and ASB implementations. Lives in rcal::calconfig module.</documentation>
+      </element>
+    </folder>
+    <folder name="Service Layer" id="f-service">
+      <element xsi:type="archimate:ApplicationInterface" name="AbstractService" id="e-abstractservice">
+        <documentation>High-level service interface above AbstractServiceBus (rcal::service). Manages service identity (system_id, service_id, subsystem_ids), lifecycle state (activate, deactivate, reset), and provides convenience passthroughs for typed message creation, readers (create_reader with callback), and writers (create_writer). Lives in rcal::service module. Ref: OMSC-SPC-008 §9 AbstractService.</documentation>
+      </element>
+      <element xsi:type="archimate:ApplicationComponent" name="AbstractServiceImpl(A)" id="e-abstractserviceimpl">
+        <documentation>Generic concrete implementation of AbstractService, parameterized over A: AbstractCal. Holds the ASB by value, owns a Vec of boxed readers for lifetime management, and enforces single-activation semantics via a monitor Mutex. create_reader() wraps closures in CallbackListener to adapt F: Fn(&amp;Arc&lt;M&gt;, &amp;str) to the MessageListener trait. Lives in rcal::service module.</documentation>
+      </element>
+      <element xsi:type="archimate:DataObject" name="ServiceLifecycleState" id="e-servicelifecyclestate">
+        <documentation>Enum for AbstractService lifecycle: Inactive (initial, no traffic), Active (processing messages). Transitions enforced by activate(), deactivate(), and reset(). Lives in rcal::service module.</documentation>
+      </element>
+      <element xsi:type="archimate:ApplicationFunction" name="service_status_loop!" id="e-servicestatusloop">
+        <documentation>Macro that spawns a tokio task executing $body then sleeping $interval, looping forever. All captured variables must be Send + 'static. Returns JoinHandle&lt;()&gt;. Typical use: periodic CAL message publish loop in a service background task. Lives in rcal::service (re-exported via #[macro_export]). Ref: rcal::service_status_loop.</documentation>
+      </element>
+    </folder>
   </folder>
   <folder name="Technology" id="f-tech" type="technology">
     <element xsi:type="archimate:TechnologyService" name="ASB Network Service" id="e-asbtech">
@@ -258,6 +277,16 @@
     <element xsi:type="archimate:RealizationRelationship" id="r-reliability-c005434" source="e-reliability" target="req-cal-005434"/>
     <element xsi:type="archimate:RealizationRelationship" id="r-reliability-c016076" source="e-reliability" target="req-cal-016076"/>
     <element xsi:type="archimate:RealizationRelationship" id="r-tbf-c005431" source="e-tbf" target="req-cal-005431"/>
+    <!-- CalConfig -->
+    <element xsi:type="archimate:AssociationRelationship" id="r-calconfig-cal" source="e-calconfig" target="e-abstractcal"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-calconfig-zmqasb" source="e-calconfig" target="e-zmqasb"/>
+    <!-- AbstractService and AbstractServiceImpl -->
+    <element xsi:type="archimate:RealizationRelationship" id="r-svcimpl-real-svc" source="e-abstractserviceimpl" target="e-abstractservice"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-svc-cal" source="e-abstractservice" target="e-abstractcal"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-svcimpl-cal" source="e-abstractserviceimpl" target="e-abstractcal"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-svcimpl-config" source="e-abstractserviceimpl" target="e-calconfig"/>
+    <element xsi:type="archimate:CompositionRelationship" id="r-svc-lifecycle" source="e-abstractserviceimpl" target="e-servicelifecyclestate"/>
+    <element xsi:type="archimate:AssociationRelationship" id="r-svcimpl-loop" source="e-servicestatusloop" target="e-abstractservice"/>
   </folder>
   <folder name="Motivation" id="f-motivation" type="motivation">
     <element xsi:type="archimate:Requirement" name="CAL-005179" id="req-cal-005179">

--- a/design/uml/component.puml
+++ b/design/uml/component.puml
@@ -1,0 +1,117 @@
+@startuml rcal-component
+' OMS Rust CAL Core — Component / Package Diagram
+' Ref: OMSC-SPC-001 rev L, OMSC-SPC-008 rev K
+' Rendered with PlantUML (https://plantuml.com)
+' Preview: https://www.plantuml.com/plantuml/uml/
+
+skinparam componentStyle rectangle
+skinparam packageStyle frame
+skinparam defaultFontName Helvetica
+
+package "rcal" {
+  package "rcal::uci" {
+    interface "CalMessage" <<trait>>
+    interface "CalSubMessage" <<trait>>
+    class "CalError" <<struct>>
+    class "CalErrorKind" <<enum>>
+    interface "CalResult<T>" <<type alias>>
+    CalResult ..> CalError
+    CalError *-- CalErrorKind
+  }
+
+  package "rcal::uci::base" {
+    class "UUID" <<newtype>>
+  }
+
+  package "rcal::xs" {
+    note "XSD primitive type aliases\n(Boolean, Long, Int, Short,\nDecimal, String, DateTime, …)" as N_xs
+  }
+
+  package "rcal::calconfig" {
+    class "CalConfig" <<struct>>
+    note right of CalConfig : TOML deserialization\n[system], [[transport]],\n[[service]], [uuid-factory]
+  }
+
+  package "rcal::cal" {
+    interface "AbstractCal" <<trait>>
+    interface "AbstractCalExt<M>" <<trait>>
+    interface "AbstractWriter<M>" <<trait>>
+    interface "AbstractReader<M>" <<trait>>
+    interface "MessageListener<M>" <<trait>>
+    class "TopicQos" <<struct>>
+    class "MessageHeaderDefaults" <<struct>>
+    class "CalFactory" <<fn get_cal()>>
+
+    AbstractCal <|-- AbstractCalExt
+    AbstractCalExt --> AbstractWriter
+    AbstractCalExt --> AbstractReader
+    AbstractReader --> MessageListener
+    AbstractCal --> MessageHeaderDefaults
+    CalFactory ..> AbstractCal : "creates / caches"
+    CalFactory ..> CalConfig : "reads"
+  }
+
+  package "rcal::asb" {
+    interface "AbstractServiceBus" <<trait>>
+    interface "AsbStatusListener" <<trait>>
+    class "AsbStatus" <<struct>>
+    class "AsbConnectionState" <<enum>>
+
+    AbstractCal --|> AbstractServiceBus : "supertrait"
+    AbstractServiceBus --> AsbStatus
+    AbstractServiceBus --> AsbStatusListener
+    AsbStatus *-- AsbConnectionState
+  }
+
+  package "rcal::externalizer" {
+    interface "Externalizer<M>" <<trait>>
+    interface "ExternalizerLoader<M>" <<trait>>
+    class "XmlExternalizer" <<struct>>
+    class "XmlExternalizerLoader" <<struct>>
+
+    ExternalizerLoader --> Externalizer
+    XmlExternalizer ..|> Externalizer
+    XmlExternalizerLoader ..|> ExternalizerLoader
+  }
+
+  package "rcal::asb::zmq" <<optional: feature=zmq>> {
+    class "ZmqAsb" <<struct>>
+    class "ZmqWriter<M>" <<struct>>
+    class "ZmqReader<M>" <<struct>>
+    class "SerializationFormat" <<enum>>
+
+    ZmqAsb ..|> AbstractServiceBus
+    ZmqAsb ..|> AbstractCal
+    ZmqAsb ..|> "AbstractCalExt<M>"
+    ZmqWriter ..|> AbstractWriter
+    ZmqReader ..|> AbstractReader
+    ZmqAsb *-- ZmqWriter
+    ZmqAsb *-- ZmqReader
+    ZmqWriter --> Externalizer
+    ZmqReader --> Externalizer
+    ZmqAsb --> XmlExternalizerLoader
+    ZmqAsb --> SerializationFormat
+  }
+
+  package "rcal::service" {
+    interface "AbstractService" <<trait>>
+    class "AbstractServiceImpl<A>" <<struct>>
+    class "ServiceLifecycleState" <<enum>>
+    class "service_status_loop!" <<macro>>
+
+    AbstractServiceImpl ..|> AbstractService
+    AbstractServiceImpl --> AbstractCal
+    AbstractServiceImpl --> CalConfig
+    AbstractServiceImpl *-- ServiceLifecycleState
+    "service_status_loop!" ..> AbstractService : "used with"
+  }
+}
+
+package "Application Code" <<external>> {
+  class "CAL Client" <<user code>>
+  CAL Client --> AbstractService
+  CAL Client --> CalFactory
+  CAL Client ..> "service_status_loop!" : "invokes"
+}
+
+@enduml

--- a/design/uml/component.puml
+++ b/design/uml/component.puml
@@ -4,6 +4,7 @@
 ' Rendered with PlantUML (https://plantuml.com)
 ' Preview: https://www.plantuml.com/plantuml/uml/
 
+top to bottom direction
 skinparam componentStyle rectangle
 skinparam packageStyle frame
 skinparam defaultFontName Helvetica
@@ -109,9 +110,9 @@ package "rcal" {
 
 package "Application Code" <<external>> {
   class "CAL Client" <<user code>>
-  CAL Client --> AbstractService
-  CAL Client --> CalFactory
-  CAL Client ..> "service_status_loop!" : "invokes"
+  "CAL Client" --> AbstractService
+  "CAL Client" --> CalFactory
+  "CAL Client" ..> "service_status_loop!" : "invokes"
 }
 
 @enduml

--- a/design/uml/component.puml
+++ b/design/uml/component.puml
@@ -108,6 +108,16 @@ package "rcal" {
   }
 }
 
+' Force vertical stacking of packages
+"rcal::uci" -[hidden]d-> "rcal::calconfig"
+"rcal::uci::base" -[hidden]d-> "rcal::calconfig"
+"rcal::xs" -[hidden]d-> "rcal::calconfig"
+"rcal::calconfig" -[hidden]d-> "rcal::cal"
+"rcal::cal" -[hidden]d-> "rcal::asb"
+"rcal::asb" -[hidden]d-> "rcal::externalizer"
+"rcal::externalizer" -[hidden]d-> "rcal::asb::zmq"
+"rcal::asb::zmq" -[hidden]d-> "rcal::service"
+
 package "Application Code" <<external>> {
   class "CAL Client" <<user code>>
   "CAL Client" --> AbstractService

--- a/design/uml/message_flow.puml
+++ b/design/uml/message_flow.puml
@@ -1,0 +1,72 @@
+@startuml rcal-message-flow
+' OMS Rust CAL Core — Message Publish/Receive Flow (Sequence Diagram)
+' Ref: OMSC-SPC-001 rev L §5.4–5.8
+' Covers: CAL-005201, CAL-005364, CAL-005374, CAL-005379, CAL-005392
+
+skinparam defaultFontName Helvetica
+skinparam sequenceArrowThickness 1.5
+skinparam roundcorner 5
+
+actor "CAL Client" as Client
+participant "CalFactory\nget_cal()" as Factory
+participant "AbstractCal\n(ZmqAsb)" as Cal
+participant "AbstractWriter<M>\n(ZmqWriter)" as Writer
+participant "AbstractReader<M>\n(ZmqReader)" as Reader
+participant "MessageListener<M>\n(CallbackListener)" as Listener
+participant "Externalizer<M>\n(XmlExternalizer)" as Ext
+
+== Initialisation (CAL-005201, CAL-005202) ==
+
+Client -> Factory : get_cal(service_id, asb_id, config, logger)
+Factory -> Cal : ZmqAsb::new(config, logger)
+Factory --> Client : Arc<Mutex<dyn AbstractCal>>
+
+== Create Writer (CAL-005364, CAL-005210) ==
+
+Client -> Cal : create_writer("TopicName", TopicQos)
+Cal -> Writer : ZmqWriter::new(topic, qos, ext)
+Cal --> Client : Box<dyn AbstractWriter<M>>
+
+== Publish Message (CAL-005368, CAL-005369) ==
+
+Client -> Writer : write(&msg)
+Writer -> Ext : write_to_bytes(&msg)
+Ext --> Writer : Vec<u8>
+Writer -> Cal : send [group=topic, payload=bytes]\nvia write channel
+Cal --> Writer : Ok(())
+Writer --> Client : CalResult<()>
+
+== Create Reader with Callback (CAL-005374, CAL-005379) ==
+
+Client -> Cal : create_reader("TopicName", TopicQos)
+Cal -> Reader : ZmqReader::new(topic, qos, ext)
+Cal --> Client : Box<dyn AbstractReader<M>>
+
+Client -> Reader : add_listener(Arc<dyn MessageListener<M>>)
+Reader --> Client : Ok(())
+
+note over Reader : DISH socket connects\nto RADIO peer URI\n(CAL-005394)
+
+== Receive Message (CAL-005392, CAL-016046) ==
+
+[-> Reader : incoming bytes on DISH socket
+Reader -> Ext : read_from_bytes(&bytes)
+Ext --> Reader : Arc<M>
+
+loop for each registered listener
+  Reader -> Listener : on_message(&Arc<M>)
+  note right : shared ref, not clone\n(CAL-005392, CAL-016046)
+  Listener --> Reader : ()
+end
+
+note over Reader : Arc<M> dropped after\nall listeners notified\n(CAL-016045)
+
+== Service Lifecycle (AbstractService) ==
+
+Client -> Cal : AbstractServiceImpl::activate()
+Cal --> Client : Ok(())
+
+Client -> Client : service_status_loop!(interval, { write(&msg) })
+note right : macro spawns tokio task\nlooping: body → sleep → repeat
+
+@enduml

--- a/rcal/Cargo.toml
+++ b/rcal/Cargo.toml
@@ -22,7 +22,6 @@ compression = ["dep:flate2"]
 default = ["service", "zmq"]
 
 [dependencies]
-lazy_static = "1.5.0"
 regex = "1"
 mac_address = { version = "1.1.8", features = ["serde"] }
 rcal_macros = { path = "./rcal_macros", version = "2.1.0" }

--- a/rcal/src/asb/zmq.rs
+++ b/rcal/src/asb/zmq.rs
@@ -1,7 +1,5 @@
 //! omq-tokio-backed Abstract Service Bus implementation (RADIO/DISH).
 
-#![allow(dead_code)]
-
 use slog::{Logger, trace};
 use std::collections::VecDeque;
 use std::marker::PhantomData;

--- a/rcal/src/cal/mod.rs
+++ b/rcal/src/cal/mod.rs
@@ -4,7 +4,6 @@
 //! - OMSC-SPC-001 Rev L §5.4–5.8 (topics, messages, writers, readers, QoS)
 //! - OMSC-SPC-001 Rev L §5.3 (CAL initialisation, CAL-005201, CAL-005202)
 
-#![allow(dead_code)]
 #![warn(missing_docs)]
 
 use crate::asb::AbstractServiceBus;
@@ -16,9 +15,8 @@ use crate::uci::types::{
 };
 use crate::uci::{CalError, CalErrorKind, CalResult};
 use chrono::Utc;
-use lazy_static::lazy_static;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
 #[cfg(feature = "zmq")]
@@ -354,10 +352,8 @@ pub(crate) struct AsbKey {
 type CalInstance = Arc<Mutex<dyn AbstractCal>>;
 type CalFactoryMap = HashMap<AsbKey, CalInstance>;
 
-lazy_static! {
-    static ref CAL_FACTORY: tokio::sync::Mutex<CalFactoryMap> =
-        tokio::sync::Mutex::new(CalFactoryMap::new());
-}
+static CAL_FACTORY: LazyLock<tokio::sync::Mutex<CalFactoryMap>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(CalFactoryMap::new()));
 
 /// Returns the [`AbstractCal`] instance for `(service_identifier, asb_identifier)`,
 /// creating it if it does not yet exist.

--- a/rcal/src/externalizer.rs
+++ b/rcal/src/externalizer.rs
@@ -754,14 +754,14 @@ mod tests {
 
     #[test]
     fn loader_ok() {
-        let loader = XmlExternalizerLoader::default();
+        let loader = XmlExternalizerLoader;
         let ext = loader.get_externalizer("xml", "2.5", "1.0").unwrap();
         assert_eq!(ext.get_encoding(), "xml");
     }
 
     #[test]
     fn loader_unknown_encoding() {
-        let loader = XmlExternalizerLoader::default();
+        let loader = XmlExternalizerLoader;
         let result = loader.get_externalizer("binary", "2.5", "1.0");
         assert_eq!(
             result.err().unwrap().kind(),

--- a/rcal/src/service/mod.rs
+++ b/rcal/src/service/mod.rs
@@ -78,10 +78,10 @@ struct CallbackListener<M, F> {
 impl<M, F> MessageListener<M> for CallbackListener<M, F>
 where
     M: CalMessage,
-    F: Fn(Arc<M>, &str) + Send + Sync,
+    F: Fn(&Arc<M>, &str) + Send + Sync,
 {
     fn on_message(&self, message: &Arc<M>) {
-        (self.callback)(Arc::clone(message), &self.topic);
+        (self.callback)(message, &self.topic);
     }
 }
 
@@ -167,13 +167,13 @@ impl<A: AbstractCal> AbstractServiceImpl<A> {
 
     /// Creates a typed reader for `topic` with a callback closure.
     ///
-    /// The callback `F(Arc<M>, &str)` receives each message and the topic name.
+    /// The callback `F(&Arc<M>, &str)` receives each message and the topic name.
     /// The reader is kept alive for the lifetime of this service instance.
     pub fn create_reader<M, F>(&mut self, topic: &str, qos: TopicQos, callback: F) -> CalResult<()>
     where
         M: CalMessage + 'static,
         A: AbstractCalExt<M>,
-        F: Fn(Arc<M>, &str) + Send + Sync + 'static,
+        F: Fn(&Arc<M>, &str) + Send + Sync + 'static,
     {
         trace!(self.logger, "AbstractServiceImpl::create_reader";
             "service_id" => &self.service_id,
@@ -521,5 +521,19 @@ mod tests {
     fn test_parse_duration_invalid() {
         assert!(parse_duration("bad").is_err());
         assert!(parse_duration("1x").is_err());
+    }
+
+    #[tokio::test]
+    async fn service_status_loop_macro_compiles_and_runs() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let counter = Arc::new(AtomicU32::new(0));
+        let c = Arc::clone(&counter);
+        let handle = crate::service_status_loop!(Duration::from_millis(10), {
+            c.fetch_add(1, Ordering::Relaxed);
+        });
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        handle.abort();
+        let _ = handle.await;
+        assert!(counter.load(Ordering::Relaxed) >= 1);
     }
 }

--- a/rcal/src/uci/base.rs
+++ b/rcal/src/uci/base.rs
@@ -16,7 +16,6 @@
 //!   is the Rust equivalent of C++ destructors and `shutdown()` calls.
 //!
 
-#![allow(dead_code)]
 #![warn(missing_docs)]
 
 pub use uuid::timestamp::context::ContextV1;

--- a/rcal/src/uci/mod.rs
+++ b/rcal/src/uci/mod.rs
@@ -7,7 +7,6 @@
 //! - OMSC-SPC-001 Rev L §5.1.2 (Error Handling)
 //! - OMSC-SPC-008 Rev K §9.2 (UCIException)
 
-#![allow(dead_code)]
 #![warn(missing_docs)]
 
 use std::fmt;

--- a/rcal/src/xs.rs
+++ b/rcal/src/xs.rs
@@ -42,7 +42,6 @@
 //! that the CAL represent it as a **signed 64-bit integer** to provide a
 //! performant API.  CAL Clients must not rely on values outside `i64::MIN ..= i64::MAX`.
 
-#![allow(dead_code)]
 #![warn(missing_docs)]
 
 // ── Simple primitive types (OMSC-SPC-008 Table 9.1-1) ───────────────────────


### PR DESCRIPTION
## Summary

Batch cleanup of six issues from the "Cleanup, bug fixes, minor improvements" milestone:

- **#62** Replace `lazy_static!` with `std::sync::LazyLock` in `cal/mod.rs`; remove `lazy_static` crate dependency
- **#63** Change `CallbackListener` callback bound from `Fn(Arc<M>, &str)` to `Fn(&Arc<M>, &str)` — avoids a redundant atomic refcount increment on every message delivery
- **#64** Remove blanket `#![allow(dead_code)]` from `uci/base.rs`, `asb/zmq.rs`, `uci/mod.rs`, `xs.rs`, and `cal/mod.rs` — public library items don't trigger dead_code; no new warnings appeared
- **#65** Add `#[tokio::test] service_status_loop_macro_compiles_and_runs` to `service/mod.rs` — verifies the macro spawns a task and executes the body at least once
- **#74** Add top-level `permissions: contents: read` to `ci.yml` — restricts the `test` and `examples` jobs that previously inherited broad defaults; `clippy` job-level block is unaffected
- **#79** Update archimate model with `CalConfig`, `AbstractService`, `AbstractServiceImpl`, `ServiceLifecycleState`, and `service_status_loop!` elements and relations; add `design/uml/component.puml` and `design/uml/message_flow.puml` — PlantUML chosen as UML format (text-based, git-diff friendly, no GUI tooling required)

## Test plan

- [x] `cargo check --workspace --all-targets` — passes
- [x] `cargo clippy --no-deps` — passes (2 pre-existing warnings in externalizer.rs, unrelated to this PR)
- [x] `cargo fmt --all` — passes
- [x] `cargo test --workspace --all-targets` — 80 tests pass (71 unit + 9 integration + 1 doc-test)

Closes #62, #63, #64, #65, #74, #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)