### PR TITLE
chore: release v2.1.2

### DIFF
--- a/rcal/CHANGELOG.md
+++ b/rcal/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [2.1.2] - 2026-09-02
+### Bug Fixes
+
+- Remove broken intra-doc link to CompressionExternalizer([`a53d764`](https://github.com/tclarke/rcal/commit/a53d7645ba59d0dcad8fa99ee7577249c55f59a8))
+
+
 ## [2.1.1] - 2026-09-02
 ### Bug Fixes
 

--- a/rcal/Cargo.toml
+++ b/rcal/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["rcal_macros", "xsd-subset", "examples/simple_two_service"]
 
 [workspace.package]
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tclarke/rcal"
@@ -24,7 +24,7 @@ default = ["service", "zmq"]
 [dependencies]
 regex = "1"
 mac_address = { version = "1.1.8", features = ["serde"] }
-rcal_macros = { path = "./rcal_macros", version = "2.1.1" }
+rcal_macros = { path = "./rcal_macros", version = "2.1.2" }
 serde = { version = "1.0.229", features = ["derive"] }
 slog = "2.8.2"
 slog-async = "2.8.0"


### PR DESCRIPTION



## 🤖 New release

* `rcal_macros`: 2.1.1 -> 2.1.2
* `rcal`: 2.1.1 -> 2.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `rcal`

<blockquote>

## [2.1.2] - 2026-09-02

### Bug Fixes

- Remove broken intra-doc link to CompressionExternalizer([`a53d764`](https://github.com/tclarke/rcal/commit/a53d7645ba59d0dcad8fa99ee7577249c55f59a8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).